### PR TITLE
5.3.0 seller removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,14 +124,13 @@ lib.Configuration.basicAuthPassword = "basicAuthPassword"; // The password to us
 
 * [PlansController](#plans_controller)
 * [SubscriptionsController](#subscriptions_controller)
-* [InvoicesController](#invoices_controller)
 * [OrdersController](#orders_controller)
+* [InvoicesController](#invoices_controller)
 * [CustomersController](#customers_controller)
-* [RecipientsController](#recipients_controller)
 * [ChargesController](#charges_controller)
 * [TransfersController](#transfers_controller)
+* [RecipientsController](#recipients_controller)
 * [TokensController](#tokens_controller)
-* [SellersController](#sellers_controller)
 * [TransactionsController](#transactions_controller)
 
 ## <a name="plans_controller"></a>![Class: ](https://apidocs.io/img/class.png ".PlansController") PlansController
@@ -167,38 +166,6 @@ function getPlan(planId, callback)
     var planId = plan_id;
 
     controller.getPlan(planId, function(error, response, context) {
-
-    
-    });
-```
-
-
-
-### <a name="delete_plan"></a>![Method: ](https://apidocs.io/img/method.png ".PlansController.deletePlan") deletePlan
-
-> Deletes a plan
-
-
-```javascript
-function deletePlan(planId, idempotencyKey, callback)
-```
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| planId |  ``` Required ```  | Plan id |
-| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
-
-
-
-#### Example Usage
-
-```javascript
-
-    var planId = plan_id;
-    var idempotencyKey = 'idempotency-key';
-
-    controller.deletePlan(planId, idempotencyKey, function(error, response, context) {
 
     
     });
@@ -434,8 +401,8 @@ function getPlans(page, size, name, status, billingType, createdSince, createdUn
 
 ```javascript
 
-    var page = 10;
-    var size = 10;
+    var page = 100;
+    var size = 100;
     var name = 'name';
     var status = 'status';
     var billingType = billing_type;
@@ -484,6 +451,38 @@ function updatePlan(planId, request, idempotencyKey, callback)
 
 
 
+### <a name="delete_plan"></a>![Method: ](https://apidocs.io/img/method.png ".PlansController.deletePlan") deletePlan
+
+> Deletes a plan
+
+
+```javascript
+function deletePlan(planId, idempotencyKey, callback)
+```
+#### Parameters
+
+| Parameter | Tags | Description |
+|-----------|------|-------------|
+| planId |  ``` Required ```  | Plan id |
+| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
+
+
+
+#### Example Usage
+
+```javascript
+
+    var planId = plan_id;
+    var idempotencyKey = 'idempotency-key';
+
+    controller.deletePlan(planId, idempotencyKey, function(error, response, context) {
+
+    
+    });
+```
+
+
+
 [Back to List of Controllers](#list_of_controllers)
 
 ## <a name="subscriptions_controller"></a>![Class: ](https://apidocs.io/img/class.png ".SubscriptionsController") SubscriptionsController
@@ -495,38 +494,6 @@ The singleton instance of the ``` SubscriptionsController ``` class can be acces
 ```javascript
 var controller = lib.SubscriptionsController;
 ```
-
-### <a name="renew_subscription"></a>![Method: ](https://apidocs.io/img/method.png ".SubscriptionsController.renewSubscription") renewSubscription
-
-> TODO: Add a method description
-
-
-```javascript
-function renewSubscription(subscriptionId, idempotencyKey, callback)
-```
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| subscriptionId |  ``` Required ```  | TODO: Add a parameter description |
-| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
-
-
-
-#### Example Usage
-
-```javascript
-
-    var subscriptionId = subscription_id;
-    var idempotencyKey = 'idempotency-key';
-
-    controller.renewSubscription(subscriptionId, idempotencyKey, function(error, response, context) {
-
-    
-    });
-```
-
-
 
 ### <a name="update_subscription_card"></a>![Method: ](https://apidocs.io/img/method.png ".SubscriptionsController.updateSubscriptionCard") updateSubscriptionCard
 
@@ -700,6 +667,40 @@ function updateCurrentCycleStatus(subscriptionId, request, idempotencyKey, callb
 
 
 
+### <a name="update_subscription_payment_method"></a>![Method: ](https://apidocs.io/img/method.png ".SubscriptionsController.updateSubscriptionPaymentMethod") updateSubscriptionPaymentMethod
+
+> Updates the payment method from a subscription
+
+
+```javascript
+function updateSubscriptionPaymentMethod(subscriptionId, request, idempotencyKey, callback)
+```
+#### Parameters
+
+| Parameter | Tags | Description |
+|-----------|------|-------------|
+| subscriptionId |  ``` Required ```  | Subscription id |
+| request |  ``` Required ```  | Request for updating the paymentmethod from a subscription |
+| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
+
+
+
+#### Example Usage
+
+```javascript
+
+    var subscriptionId = subscription_id;
+    var request = new UpdateSubscriptionPaymentMethodRequest({"key":"value"});
+    var idempotencyKey = 'idempotency-key';
+
+    controller.updateSubscriptionPaymentMethod(subscriptionId, request, idempotencyKey, function(error, response, context) {
+
+    
+    });
+```
+
+
+
 ### <a name="delete_discount"></a>![Method: ](https://apidocs.io/img/method.png ".SubscriptionsController.deleteDiscount") deleteDiscount
 
 > Deletes a discount
@@ -763,8 +764,8 @@ function getSubscriptionItems(subscriptionId, page, size, name, code, status, de
 ```javascript
 
     var subscriptionId = subscription_id;
-    var page = 223;
-    var size = 223;
+    var page = 100;
+    var size = 100;
     var name = 'name';
     var code = 'code';
     var status = 'status';
@@ -773,40 +774,6 @@ function getSubscriptionItems(subscriptionId, page, size, name, code, status, de
     var createdUntil = created_until;
 
     controller.getSubscriptionItems(subscriptionId, page, size, name, code, status, description, createdSince, createdUntil, function(error, response, context) {
-
-    
-    });
-```
-
-
-
-### <a name="update_subscription_payment_method"></a>![Method: ](https://apidocs.io/img/method.png ".SubscriptionsController.updateSubscriptionPaymentMethod") updateSubscriptionPaymentMethod
-
-> Updates the payment method from a subscription
-
-
-```javascript
-function updateSubscriptionPaymentMethod(subscriptionId, request, idempotencyKey, callback)
-```
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| subscriptionId |  ``` Required ```  | Subscription id |
-| request |  ``` Required ```  | Request for updating the paymentmethod from a subscription |
-| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
-
-
-
-#### Example Usage
-
-```javascript
-
-    var subscriptionId = subscription_id;
-    var request = new UpdateSubscriptionPaymentMethodRequest({"key":"value"});
-    var idempotencyKey = 'idempotency-key';
-
-    controller.updateSubscriptionPaymentMethod(subscriptionId, request, idempotencyKey, function(error, response, context) {
 
     
     });
@@ -877,8 +844,8 @@ function getSubscriptions(page, size, code, billingType, customerId, planId, car
 
 ```javascript
 
-    var page = 223;
-    var size = 223;
+    var page = 100;
+    var size = 100;
     var code = 'code';
     var billingType = billing_type;
     var customerId = customer_id;
@@ -1002,38 +969,6 @@ function createUsage(subscriptionId, itemId, body, idempotencyKey, callback)
 
 
 
-### <a name="get_discount_by_id"></a>![Method: ](https://apidocs.io/img/method.png ".SubscriptionsController.getDiscountById") getDiscountById
-
-> TODO: Add a method description
-
-
-```javascript
-function getDiscountById(subscriptionId, discountId, callback)
-```
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| subscriptionId |  ``` Required ```  | The subscription id |
-| discountId |  ``` Required ```  | TODO: Add a parameter description |
-
-
-
-#### Example Usage
-
-```javascript
-
-    var subscriptionId = subscription_id;
-    var discountId = 'discountId';
-
-    controller.getDiscountById(subscriptionId, discountId, function(error, response, context) {
-
-    
-    });
-```
-
-
-
 ### <a name="create_subscription"></a>![Method: ](https://apidocs.io/img/method.png ".SubscriptionsController.createSubscription") createSubscription
 
 > Creates a new subscription
@@ -1066,20 +1001,20 @@ function createSubscription(body, idempotencyKey, callback)
 
 
 
-### <a name="get_increment_by_id"></a>![Method: ](https://apidocs.io/img/method.png ".SubscriptionsController.getIncrementById") getIncrementById
+### <a name="get_discount_by_id"></a>![Method: ](https://apidocs.io/img/method.png ".SubscriptionsController.getDiscountById") getDiscountById
 
 > TODO: Add a method description
 
 
 ```javascript
-function getIncrementById(subscriptionId, incrementId, callback)
+function getDiscountById(subscriptionId, discountId, callback)
 ```
 #### Parameters
 
 | Parameter | Tags | Description |
 |-----------|------|-------------|
-| subscriptionId |  ``` Required ```  | The subscription Id |
-| incrementId |  ``` Required ```  | The increment Id |
+| subscriptionId |  ``` Required ```  | The subscription id |
+| discountId |  ``` Required ```  | TODO: Add a parameter description |
 
 
 
@@ -1088,9 +1023,9 @@ function getIncrementById(subscriptionId, incrementId, callback)
 ```javascript
 
     var subscriptionId = subscription_id;
-    var incrementId = increment_id;
+    var discountId = 'discountId';
 
-    controller.getIncrementById(subscriptionId, incrementId, function(error, response, context) {
+    controller.getDiscountById(subscriptionId, discountId, function(error, response, context) {
 
     
     });
@@ -1234,6 +1169,38 @@ function getSubscriptionCycles(subscriptionId, page, size, callback)
 
 
 
+### <a name="get_increment_by_id"></a>![Method: ](https://apidocs.io/img/method.png ".SubscriptionsController.getIncrementById") getIncrementById
+
+> TODO: Add a method description
+
+
+```javascript
+function getIncrementById(subscriptionId, incrementId, callback)
+```
+#### Parameters
+
+| Parameter | Tags | Description |
+|-----------|------|-------------|
+| subscriptionId |  ``` Required ```  | The subscription Id |
+| incrementId |  ``` Required ```  | The increment Id |
+
+
+
+#### Example Usage
+
+```javascript
+
+    var subscriptionId = subscription_id;
+    var incrementId = increment_id;
+
+    controller.getIncrementById(subscriptionId, incrementId, function(error, response, context) {
+
+    
+    });
+```
+
+
+
 ### <a name="get_discounts"></a>![Method: ](https://apidocs.io/img/method.png ".SubscriptionsController.getDiscounts") getDiscounts
 
 > TODO: Add a method description
@@ -1257,8 +1224,8 @@ function getDiscounts(subscriptionId, page, size, callback)
 ```javascript
 
     var subscriptionId = subscription_id;
-    var page = 223;
-    var size = 223;
+    var page = 100;
+    var size = 100;
 
     controller.getDiscounts(subscriptionId, page, size, function(error, response, context) {
 
@@ -1359,8 +1326,8 @@ function getIncrements(subscriptionId, page, size, callback)
 ```javascript
 
     var subscriptionId = subscription_id;
-    var page = 223;
-    var size = 223;
+    var page = 100;
+    var size = 100;
 
     controller.getIncrements(subscriptionId, page, size, function(error, response, context) {
 
@@ -1567,8 +1534,8 @@ function getUsages(subscriptionId, itemId, page, size, code, group, usedSince, u
 
     var subscriptionId = subscription_id;
     var itemId = item_id;
-    var page = 223;
-    var size = 223;
+    var page = 100;
+    var size = 100;
     var code = 'code';
     var group = 'group';
     var usedSince = date("D M d, Y G:i");
@@ -1682,6 +1649,38 @@ function getSubscriptionCycleById(subscriptionId, cycleId, callback)
 
 
 
+### <a name="renew_subscription"></a>![Method: ](https://apidocs.io/img/method.png ".SubscriptionsController.renewSubscription") renewSubscription
+
+> TODO: Add a method description
+
+
+```javascript
+function renewSubscription(subscriptionId, idempotencyKey, callback)
+```
+#### Parameters
+
+| Parameter | Tags | Description |
+|-----------|------|-------------|
+| subscriptionId |  ``` Required ```  | TODO: Add a parameter description |
+| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
+
+
+
+#### Example Usage
+
+```javascript
+
+    var subscriptionId = subscription_id;
+    var idempotencyKey = 'idempotency-key';
+
+    controller.renewSubscription(subscriptionId, idempotencyKey, function(error, response, context) {
+
+    
+    });
+```
+
+
+
 ### <a name="get_usage_report"></a>![Method: ](https://apidocs.io/img/method.png ".SubscriptionsController.getUsageReport") getUsageReport
 
 > TODO: Add a method description
@@ -1707,264 +1706,6 @@ function getUsageReport(subscriptionId, periodId, callback)
     var periodId = period_id;
 
     controller.getUsageReport(subscriptionId, periodId, function(error, response, context) {
-
-    
-    });
-```
-
-
-
-[Back to List of Controllers](#list_of_controllers)
-
-## <a name="invoices_controller"></a>![Class: ](https://apidocs.io/img/class.png ".InvoicesController") InvoicesController
-
-### Get singleton instance
-
-The singleton instance of the ``` InvoicesController ``` class can be accessed from the API Client.
-
-```javascript
-var controller = lib.InvoicesController;
-```
-
-### <a name="update_invoice_metadata"></a>![Method: ](https://apidocs.io/img/method.png ".InvoicesController.updateInvoiceMetadata") updateInvoiceMetadata
-
-> Updates the metadata from an invoice
-
-
-```javascript
-function updateInvoiceMetadata(invoiceId, request, idempotencyKey, callback)
-```
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| invoiceId |  ``` Required ```  | The invoice id |
-| request |  ``` Required ```  | Request for updating the invoice metadata |
-| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
-
-
-
-#### Example Usage
-
-```javascript
-
-    var invoiceId = invoice_id;
-    var request = new UpdateMetadataRequest({"key":"value"});
-    var idempotencyKey = 'idempotency-key';
-
-    controller.updateInvoiceMetadata(invoiceId, request, idempotencyKey, function(error, response, context) {
-
-    
-    });
-```
-
-
-
-### <a name="get_partial_invoice"></a>![Method: ](https://apidocs.io/img/method.png ".InvoicesController.getPartialInvoice") getPartialInvoice
-
-> TODO: Add a method description
-
-
-```javascript
-function getPartialInvoice(subscriptionId, callback)
-```
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| subscriptionId |  ``` Required ```  | Subscription Id |
-
-
-
-#### Example Usage
-
-```javascript
-
-    var subscriptionId = subscription_id;
-
-    controller.getPartialInvoice(subscriptionId, function(error, response, context) {
-
-    
-    });
-```
-
-
-
-### <a name="cancel_invoice"></a>![Method: ](https://apidocs.io/img/method.png ".InvoicesController.cancelInvoice") cancelInvoice
-
-> Cancels an invoice
-
-
-```javascript
-function cancelInvoice(invoiceId, idempotencyKey, callback)
-```
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| invoiceId |  ``` Required ```  | Invoice id |
-| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
-
-
-
-#### Example Usage
-
-```javascript
-
-    var invoiceId = invoice_id;
-    var idempotencyKey = 'idempotency-key';
-
-    controller.cancelInvoice(invoiceId, idempotencyKey, function(error, response, context) {
-
-    
-    });
-```
-
-
-
-### <a name="create_invoice"></a>![Method: ](https://apidocs.io/img/method.png ".InvoicesController.createInvoice") createInvoice
-
-> Create an Invoice
-
-
-```javascript
-function createInvoice(subscriptionId, cycleId, request, idempotencyKey, callback)
-```
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| subscriptionId |  ``` Required ```  | Subscription Id |
-| cycleId |  ``` Required ```  | Cycle Id |
-| request |  ``` Optional ```  | TODO: Add a parameter description |
-| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
-
-
-
-#### Example Usage
-
-```javascript
-
-    var subscriptionId = subscription_id;
-    var cycleId = cycle_id;
-    var request = new CreateInvoiceRequest({"key":"value"});
-    var idempotencyKey = 'idempotency-key';
-
-    controller.createInvoice(subscriptionId, cycleId, request, idempotencyKey, function(error, response, context) {
-
-    
-    });
-```
-
-
-
-### <a name="get_invoices"></a>![Method: ](https://apidocs.io/img/method.png ".InvoicesController.getInvoices") getInvoices
-
-> Gets all invoices
-
-
-```javascript
-function getInvoices(page, size, code, customerId, subscriptionId, createdSince, createdUntil, status, dueSince, dueUntil, customerDocument, callback)
-```
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| page |  ``` Optional ```  | Page number |
-| size |  ``` Optional ```  | Page size |
-| code |  ``` Optional ```  | Filter for Invoice's code |
-| customerId |  ``` Optional ```  | Filter for Invoice's customer id |
-| subscriptionId |  ``` Optional ```  | Filter for Invoice's subscription id |
-| createdSince |  ``` Optional ```  | Filter for Invoice's creation date start range |
-| createdUntil |  ``` Optional ```  | Filter for Invoices creation date end range |
-| status |  ``` Optional ```  | Filter for Invoice's status |
-| dueSince |  ``` Optional ```  | Filter for Invoice's due date start range |
-| dueUntil |  ``` Optional ```  | Filter for Invoice's due date end range |
-| customerDocument |  ``` Optional ```  | TODO: Add a parameter description |
-
-
-
-#### Example Usage
-
-```javascript
-
-    var page = 223;
-    var size = 223;
-    var code = 'code';
-    var customerId = customer_id;
-    var subscriptionId = subscription_id;
-    var createdSince = date("D M d, Y G:i");
-    var createdUntil = date("D M d, Y G:i");
-    var status = 'status';
-    var dueSince = date("D M d, Y G:i");
-    var dueUntil = date("D M d, Y G:i");
-    var customerDocument = customer_document;
-
-    controller.getInvoices(page, size, code, customerId, subscriptionId, createdSince, createdUntil, status, dueSince, dueUntil, customerDocument, function(error, response, context) {
-
-    
-    });
-```
-
-
-
-### <a name="get_invoice"></a>![Method: ](https://apidocs.io/img/method.png ".InvoicesController.getInvoice") getInvoice
-
-> Gets an invoice
-
-
-```javascript
-function getInvoice(invoiceId, callback)
-```
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| invoiceId |  ``` Required ```  | Invoice Id |
-
-
-
-#### Example Usage
-
-```javascript
-
-    var invoiceId = invoice_id;
-
-    controller.getInvoice(invoiceId, function(error, response, context) {
-
-    
-    });
-```
-
-
-
-### <a name="update_invoice_status"></a>![Method: ](https://apidocs.io/img/method.png ".InvoicesController.updateInvoiceStatus") updateInvoiceStatus
-
-> Updates the status from an invoice
-
-
-```javascript
-function updateInvoiceStatus(invoiceId, request, idempotencyKey, callback)
-```
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| invoiceId |  ``` Required ```  | Invoice Id |
-| request |  ``` Required ```  | Request for updating an invoice's status |
-| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
-
-
-
-#### Example Usage
-
-```javascript
-
-    var invoiceId = invoice_id;
-    var request = new UpdateInvoiceStatusRequest({"key":"value"});
-    var idempotencyKey = 'idempotency-key';
-
-    controller.updateInvoiceStatus(invoiceId, request, idempotencyKey, function(error, response, context) {
 
     
     });
@@ -2010,8 +1751,8 @@ function getOrders(page, size, code, status, createdSince, createdUntil, custome
 
 ```javascript
 
-    var page = 223;
-    var size = 223;
+    var page = 100;
+    var size = 100;
     var code = 'code';
     var status = 'status';
     var createdSince = date("D M d, Y G:i");
@@ -2019,6 +1760,38 @@ function getOrders(page, size, code, status, createdSince, createdUntil, custome
     var customerId = customer_id;
 
     controller.getOrders(page, size, code, status, createdSince, createdUntil, customerId, function(error, response, context) {
+
+    
+    });
+```
+
+
+
+### <a name="delete_all_order_items"></a>![Method: ](https://apidocs.io/img/method.png ".OrdersController.deleteAllOrderItems") deleteAllOrderItems
+
+> TODO: Add a method description
+
+
+```javascript
+function deleteAllOrderItems(orderId, idempotencyKey, callback)
+```
+#### Parameters
+
+| Parameter | Tags | Description |
+|-----------|------|-------------|
+| orderId |  ``` Required ```  | Order Id |
+| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
+
+
+
+#### Example Usage
+
+```javascript
+
+    var orderId = 'orderId';
+    var idempotencyKey = 'idempotency-key';
+
+    controller.deleteAllOrderItems(orderId, idempotencyKey, function(error, response, context) {
 
     
     });
@@ -2055,38 +1828,6 @@ function updateOrderItem(orderId, itemId, request, idempotencyKey, callback)
     var idempotencyKey = 'idempotency-key';
 
     controller.updateOrderItem(orderId, itemId, request, idempotencyKey, function(error, response, context) {
-
-    
-    });
-```
-
-
-
-### <a name="delete_all_order_items"></a>![Method: ](https://apidocs.io/img/method.png ".OrdersController.deleteAllOrderItems") deleteAllOrderItems
-
-> TODO: Add a method description
-
-
-```javascript
-function deleteAllOrderItems(orderId, idempotencyKey, callback)
-```
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| orderId |  ``` Required ```  | Order Id |
-| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
-
-
-
-#### Example Usage
-
-```javascript
-
-    var orderId = 'orderId';
-    var idempotencyKey = 'idempotency-key';
-
-    controller.deleteAllOrderItems(orderId, idempotencyKey, function(error, response, context) {
 
     
     });
@@ -2326,6 +2067,264 @@ function getOrder(orderId, callback)
 
 [Back to List of Controllers](#list_of_controllers)
 
+## <a name="invoices_controller"></a>![Class: ](https://apidocs.io/img/class.png ".InvoicesController") InvoicesController
+
+### Get singleton instance
+
+The singleton instance of the ``` InvoicesController ``` class can be accessed from the API Client.
+
+```javascript
+var controller = lib.InvoicesController;
+```
+
+### <a name="get_partial_invoice"></a>![Method: ](https://apidocs.io/img/method.png ".InvoicesController.getPartialInvoice") getPartialInvoice
+
+> TODO: Add a method description
+
+
+```javascript
+function getPartialInvoice(subscriptionId, callback)
+```
+#### Parameters
+
+| Parameter | Tags | Description |
+|-----------|------|-------------|
+| subscriptionId |  ``` Required ```  | Subscription Id |
+
+
+
+#### Example Usage
+
+```javascript
+
+    var subscriptionId = subscription_id;
+
+    controller.getPartialInvoice(subscriptionId, function(error, response, context) {
+
+    
+    });
+```
+
+
+
+### <a name="cancel_invoice"></a>![Method: ](https://apidocs.io/img/method.png ".InvoicesController.cancelInvoice") cancelInvoice
+
+> Cancels an invoice
+
+
+```javascript
+function cancelInvoice(invoiceId, idempotencyKey, callback)
+```
+#### Parameters
+
+| Parameter | Tags | Description |
+|-----------|------|-------------|
+| invoiceId |  ``` Required ```  | Invoice id |
+| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
+
+
+
+#### Example Usage
+
+```javascript
+
+    var invoiceId = invoice_id;
+    var idempotencyKey = 'idempotency-key';
+
+    controller.cancelInvoice(invoiceId, idempotencyKey, function(error, response, context) {
+
+    
+    });
+```
+
+
+
+### <a name="create_invoice"></a>![Method: ](https://apidocs.io/img/method.png ".InvoicesController.createInvoice") createInvoice
+
+> Create an Invoice
+
+
+```javascript
+function createInvoice(subscriptionId, cycleId, request, idempotencyKey, callback)
+```
+#### Parameters
+
+| Parameter | Tags | Description |
+|-----------|------|-------------|
+| subscriptionId |  ``` Required ```  | Subscription Id |
+| cycleId |  ``` Required ```  | Cycle Id |
+| request |  ``` Optional ```  | TODO: Add a parameter description |
+| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
+
+
+
+#### Example Usage
+
+```javascript
+
+    var subscriptionId = subscription_id;
+    var cycleId = cycle_id;
+    var request = new CreateInvoiceRequest({"key":"value"});
+    var idempotencyKey = 'idempotency-key';
+
+    controller.createInvoice(subscriptionId, cycleId, request, idempotencyKey, function(error, response, context) {
+
+    
+    });
+```
+
+
+
+### <a name="update_invoice_metadata"></a>![Method: ](https://apidocs.io/img/method.png ".InvoicesController.updateInvoiceMetadata") updateInvoiceMetadata
+
+> Updates the metadata from an invoice
+
+
+```javascript
+function updateInvoiceMetadata(invoiceId, request, idempotencyKey, callback)
+```
+#### Parameters
+
+| Parameter | Tags | Description |
+|-----------|------|-------------|
+| invoiceId |  ``` Required ```  | The invoice id |
+| request |  ``` Required ```  | Request for updating the invoice metadata |
+| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
+
+
+
+#### Example Usage
+
+```javascript
+
+    var invoiceId = invoice_id;
+    var request = new UpdateMetadataRequest({"key":"value"});
+    var idempotencyKey = 'idempotency-key';
+
+    controller.updateInvoiceMetadata(invoiceId, request, idempotencyKey, function(error, response, context) {
+
+    
+    });
+```
+
+
+
+### <a name="get_invoices"></a>![Method: ](https://apidocs.io/img/method.png ".InvoicesController.getInvoices") getInvoices
+
+> Gets all invoices
+
+
+```javascript
+function getInvoices(page, size, code, customerId, subscriptionId, createdSince, createdUntil, status, dueSince, dueUntil, customerDocument, callback)
+```
+#### Parameters
+
+| Parameter | Tags | Description |
+|-----------|------|-------------|
+| page |  ``` Optional ```  | Page number |
+| size |  ``` Optional ```  | Page size |
+| code |  ``` Optional ```  | Filter for Invoice's code |
+| customerId |  ``` Optional ```  | Filter for Invoice's customer id |
+| subscriptionId |  ``` Optional ```  | Filter for Invoice's subscription id |
+| createdSince |  ``` Optional ```  | Filter for Invoice's creation date start range |
+| createdUntil |  ``` Optional ```  | Filter for Invoices creation date end range |
+| status |  ``` Optional ```  | Filter for Invoice's status |
+| dueSince |  ``` Optional ```  | Filter for Invoice's due date start range |
+| dueUntil |  ``` Optional ```  | Filter for Invoice's due date end range |
+| customerDocument |  ``` Optional ```  | TODO: Add a parameter description |
+
+
+
+#### Example Usage
+
+```javascript
+
+    var page = 100;
+    var size = 100;
+    var code = 'code';
+    var customerId = customer_id;
+    var subscriptionId = subscription_id;
+    var createdSince = date("D M d, Y G:i");
+    var createdUntil = date("D M d, Y G:i");
+    var status = 'status';
+    var dueSince = date("D M d, Y G:i");
+    var dueUntil = date("D M d, Y G:i");
+    var customerDocument = customer_document;
+
+    controller.getInvoices(page, size, code, customerId, subscriptionId, createdSince, createdUntil, status, dueSince, dueUntil, customerDocument, function(error, response, context) {
+
+    
+    });
+```
+
+
+
+### <a name="get_invoice"></a>![Method: ](https://apidocs.io/img/method.png ".InvoicesController.getInvoice") getInvoice
+
+> Gets an invoice
+
+
+```javascript
+function getInvoice(invoiceId, callback)
+```
+#### Parameters
+
+| Parameter | Tags | Description |
+|-----------|------|-------------|
+| invoiceId |  ``` Required ```  | Invoice Id |
+
+
+
+#### Example Usage
+
+```javascript
+
+    var invoiceId = invoice_id;
+
+    controller.getInvoice(invoiceId, function(error, response, context) {
+
+    
+    });
+```
+
+
+
+### <a name="update_invoice_status"></a>![Method: ](https://apidocs.io/img/method.png ".InvoicesController.updateInvoiceStatus") updateInvoiceStatus
+
+> Updates the status from an invoice
+
+
+```javascript
+function updateInvoiceStatus(invoiceId, request, idempotencyKey, callback)
+```
+#### Parameters
+
+| Parameter | Tags | Description |
+|-----------|------|-------------|
+| invoiceId |  ``` Required ```  | Invoice Id |
+| request |  ``` Required ```  | Request for updating an invoice's status |
+| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
+
+
+
+#### Example Usage
+
+```javascript
+
+    var invoiceId = invoice_id;
+    var request = new UpdateInvoiceStatusRequest({"key":"value"});
+    var idempotencyKey = 'idempotency-key';
+
+    controller.updateInvoiceStatus(invoiceId, request, idempotencyKey, function(error, response, context) {
+
+    
+    });
+```
+
+
+
+[Back to List of Controllers](#list_of_controllers)
+
 ## <a name="customers_controller"></a>![Class: ](https://apidocs.io/img/class.png ".CustomersController") CustomersController
 
 ### Get singleton instance
@@ -2442,19 +2441,20 @@ function deleteAccessToken(customerId, tokenId, idempotencyKey, callback)
 
 
 
-### <a name="create_customer"></a>![Method: ](https://apidocs.io/img/method.png ".CustomersController.createCustomer") createCustomer
+### <a name="create_access_token"></a>![Method: ](https://apidocs.io/img/method.png ".CustomersController.createAccessToken") createAccessToken
 
-> Creates a new customer
+> Creates a access token for a customer
 
 
 ```javascript
-function createCustomer(request, idempotencyKey, callback)
+function createAccessToken(customerId, request, idempotencyKey, callback)
 ```
 #### Parameters
 
 | Parameter | Tags | Description |
 |-----------|------|-------------|
-| request |  ``` Required ```  | Request for creating a customer |
+| customerId |  ``` Required ```  | Customer Id |
+| request |  ``` Required ```  | Request for creating a access token |
 | idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
 
 
@@ -2463,10 +2463,11 @@ function createCustomer(request, idempotencyKey, callback)
 
 ```javascript
 
-    var request = new CreateCustomerRequest({"key":"value"});
+    var customerId = customer_id;
+    var request = new CreateAccessTokenRequest({"key":"value"});
     var idempotencyKey = 'idempotency-key';
 
-    controller.createCustomer(request, idempotencyKey, function(error, response, context) {
+    controller.createAccessToken(customerId, request, idempotencyKey, function(error, response, context) {
 
     
     });
@@ -2501,6 +2502,38 @@ function createAddress(customerId, request, idempotencyKey, callback)
     var idempotencyKey = 'idempotency-key';
 
     controller.createAddress(customerId, request, idempotencyKey, function(error, response, context) {
+
+    
+    });
+```
+
+
+
+### <a name="create_customer"></a>![Method: ](https://apidocs.io/img/method.png ".CustomersController.createCustomer") createCustomer
+
+> Creates a new customer
+
+
+```javascript
+function createCustomer(request, idempotencyKey, callback)
+```
+#### Parameters
+
+| Parameter | Tags | Description |
+|-----------|------|-------------|
+| request |  ``` Required ```  | Request for creating a customer |
+| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
+
+
+
+#### Example Usage
+
+```javascript
+
+    var request = new CreateCustomerRequest({"key":"value"});
+    var idempotencyKey = 'idempotency-key';
+
+    controller.createCustomer(request, idempotencyKey, function(error, response, context) {
 
     
     });
@@ -2665,8 +2698,8 @@ function getCustomers(name, document, page, size, email, code, callback)
 
     var name = 'name';
     var document = 'document';
-    var page = 223;
-    var size = 223;
+    var page = 192;
+    var size = 192;
     var email = 'email';
     var code = 'Code';
 
@@ -2712,40 +2745,6 @@ function updateCustomer(customerId, request, idempotencyKey, callback)
 
 
 
-### <a name="create_access_token"></a>![Method: ](https://apidocs.io/img/method.png ".CustomersController.createAccessToken") createAccessToken
-
-> Creates a access token for a customer
-
-
-```javascript
-function createAccessToken(customerId, request, idempotencyKey, callback)
-```
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| customerId |  ``` Required ```  | Customer Id |
-| request |  ``` Required ```  | Request for creating a access token |
-| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
-
-
-
-#### Example Usage
-
-```javascript
-
-    var customerId = customer_id;
-    var request = new CreateAccessTokenRequest({"key":"value"});
-    var idempotencyKey = 'idempotency-key';
-
-    controller.createAccessToken(customerId, request, idempotencyKey, function(error, response, context) {
-
-    
-    });
-```
-
-
-
 ### <a name="get_access_tokens"></a>![Method: ](https://apidocs.io/img/method.png ".CustomersController.getAccessTokens") getAccessTokens
 
 > Get all access tokens from a customer
@@ -2769,8 +2768,8 @@ function getAccessTokens(customerId, page, size, callback)
 ```javascript
 
     var customerId = customer_id;
-    var page = 223;
-    var size = 223;
+    var page = 192;
+    var size = 192;
 
     controller.getAccessTokens(customerId, page, size, function(error, response, context) {
 
@@ -2803,8 +2802,8 @@ function getCards(customerId, page, size, callback)
 ```javascript
 
     var customerId = customer_id;
-    var page = 223;
-    var size = 223;
+    var page = 192;
+    var size = 192;
 
     controller.getCards(customerId, page, size, function(error, response, context) {
 
@@ -2971,8 +2970,8 @@ function getAddresses(customerId, page, size, callback)
 ```javascript
 
     var customerId = customer_id;
-    var page = 223;
-    var size = 223;
+    var page = 192;
+    var size = 192;
 
     controller.getAddresses(customerId, page, size, function(error, response, context) {
 
@@ -3046,720 +3045,6 @@ function getCard(customerId, cardId, callback)
 
 [Back to List of Controllers](#list_of_controllers)
 
-## <a name="recipients_controller"></a>![Class: ](https://apidocs.io/img/class.png ".RecipientsController") RecipientsController
-
-### Get singleton instance
-
-The singleton instance of the ``` RecipientsController ``` class can be accessed from the API Client.
-
-```javascript
-var controller = lib.RecipientsController;
-```
-
-### <a name="update_recipient"></a>![Method: ](https://apidocs.io/img/method.png ".RecipientsController.updateRecipient") updateRecipient
-
-> Updates a recipient
-
-
-```javascript
-function updateRecipient(recipientId, request, idempotencyKey, callback)
-```
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| recipientId |  ``` Required ```  | Recipient id |
-| request |  ``` Required ```  | Recipient data |
-| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
-
-
-
-#### Example Usage
-
-```javascript
-
-    var recipientId = recipient_id;
-    var request = new UpdateRecipientRequest({"key":"value"});
-    var idempotencyKey = 'idempotency-key';
-
-    controller.updateRecipient(recipientId, request, idempotencyKey, function(error, response, context) {
-
-    
-    });
-```
-
-
-
-### <a name="create_anticipation"></a>![Method: ](https://apidocs.io/img/method.png ".RecipientsController.createAnticipation") createAnticipation
-
-> Creates an anticipation
-
-
-```javascript
-function createAnticipation(recipientId, request, idempotencyKey, callback)
-```
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| recipientId |  ``` Required ```  | Recipient id |
-| request |  ``` Required ```  | Anticipation data |
-| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
-
-
-
-#### Example Usage
-
-```javascript
-
-    var recipientId = recipient_id;
-    var request = new CreateAnticipationRequest({"key":"value"});
-    var idempotencyKey = 'idempotency-key';
-
-    controller.createAnticipation(recipientId, request, idempotencyKey, function(error, response, context) {
-
-    
-    });
-```
-
-
-
-### <a name="get_anticipation_limits"></a>![Method: ](https://apidocs.io/img/method.png ".RecipientsController.getAnticipationLimits") getAnticipationLimits
-
-> Gets the anticipation limits for a recipient
-
-
-```javascript
-function getAnticipationLimits(recipientId, timeframe, paymentDate, callback)
-```
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| recipientId |  ``` Required ```  | Recipient id |
-| timeframe |  ``` Required ```  | Timeframe |
-| paymentDate |  ``` Required ```  | Anticipation payment date |
-
-
-
-#### Example Usage
-
-```javascript
-
-    var recipientId = recipient_id;
-    var timeframe = 'timeframe';
-    var paymentDate = date("D M d, Y G:i");
-
-    controller.getAnticipationLimits(recipientId, timeframe, paymentDate, function(error, response, context) {
-
-    
-    });
-```
-
-
-
-### <a name="get_recipients"></a>![Method: ](https://apidocs.io/img/method.png ".RecipientsController.getRecipients") getRecipients
-
-> Retrieves paginated recipients information
-
-
-```javascript
-function getRecipients(page, size, callback)
-```
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| page |  ``` Optional ```  | Page number |
-| size |  ``` Optional ```  | Page size |
-
-
-
-#### Example Usage
-
-```javascript
-
-    var page = 223;
-    var size = 223;
-
-    controller.getRecipients(page, size, function(error, response, context) {
-
-    
-    });
-```
-
-
-
-### <a name="get_withdraw_by_id"></a>![Method: ](https://apidocs.io/img/method.png ".RecipientsController.getWithdrawById") getWithdrawById
-
-> TODO: Add a method description
-
-
-```javascript
-function getWithdrawById(recipientId, withdrawalId, callback)
-```
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| recipientId |  ``` Required ```  | TODO: Add a parameter description |
-| withdrawalId |  ``` Required ```  | TODO: Add a parameter description |
-
-
-
-#### Example Usage
-
-```javascript
-
-    var recipientId = recipient_id;
-    var withdrawalId = withdrawal_id;
-
-    controller.getWithdrawById(recipientId, withdrawalId, function(error, response, context) {
-
-    
-    });
-```
-
-
-
-### <a name="update_recipient_default_bank_account"></a>![Method: ](https://apidocs.io/img/method.png ".RecipientsController.updateRecipientDefaultBankAccount") updateRecipientDefaultBankAccount
-
-> Updates the default bank account from a recipient
-
-
-```javascript
-function updateRecipientDefaultBankAccount(recipientId, request, idempotencyKey, callback)
-```
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| recipientId |  ``` Required ```  | Recipient id |
-| request |  ``` Required ```  | Bank account data |
-| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
-
-
-
-#### Example Usage
-
-```javascript
-
-    var recipientId = recipient_id;
-    var request = new UpdateRecipientBankAccountRequest({"key":"value"});
-    var idempotencyKey = 'idempotency-key';
-
-    controller.updateRecipientDefaultBankAccount(recipientId, request, idempotencyKey, function(error, response, context) {
-
-    
-    });
-```
-
-
-
-### <a name="update_recipient_metadata"></a>![Method: ](https://apidocs.io/img/method.png ".RecipientsController.updateRecipientMetadata") updateRecipientMetadata
-
-> Updates recipient metadata
-
-
-```javascript
-function updateRecipientMetadata(recipientId, request, idempotencyKey, callback)
-```
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| recipientId |  ``` Required ```  | Recipient id |
-| request |  ``` Required ```  | Metadata |
-| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
-
-
-
-#### Example Usage
-
-```javascript
-
-    var recipientId = recipient_id;
-    var request = new UpdateMetadataRequest({"key":"value"});
-    var idempotencyKey = 'idempotency-key';
-
-    controller.updateRecipientMetadata(recipientId, request, idempotencyKey, function(error, response, context) {
-
-    
-    });
-```
-
-
-
-### <a name="get_transfers"></a>![Method: ](https://apidocs.io/img/method.png ".RecipientsController.getTransfers") getTransfers
-
-> Gets a paginated list of transfers for the recipient
-
-
-```javascript
-function getTransfers(recipientId, page, size, status, createdSince, createdUntil, callback)
-```
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| recipientId |  ``` Required ```  | Recipient id |
-| page |  ``` Optional ```  | Page number |
-| size |  ``` Optional ```  | Page size |
-| status |  ``` Optional ```  | Filter for transfer status |
-| createdSince |  ``` Optional ```  | Filter for start range of transfer creation date |
-| createdUntil |  ``` Optional ```  | Filter for end range of transfer creation date |
-
-
-
-#### Example Usage
-
-```javascript
-
-    var recipientId = recipient_id;
-    var page = 223;
-    var size = 223;
-    var status = 'status';
-    var createdSince = date("D M d, Y G:i");
-    var createdUntil = date("D M d, Y G:i");
-
-    controller.getTransfers(recipientId, page, size, status, createdSince, createdUntil, function(error, response, context) {
-
-    
-    });
-```
-
-
-
-### <a name="get_transfer"></a>![Method: ](https://apidocs.io/img/method.png ".RecipientsController.getTransfer") getTransfer
-
-> Gets a transfer
-
-
-```javascript
-function getTransfer(recipientId, transferId, callback)
-```
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| recipientId |  ``` Required ```  | Recipient id |
-| transferId |  ``` Required ```  | Transfer id |
-
-
-
-#### Example Usage
-
-```javascript
-
-    var recipientId = recipient_id;
-    var transferId = transfer_id;
-
-    controller.getTransfer(recipientId, transferId, function(error, response, context) {
-
-    
-    });
-```
-
-
-
-### <a name="create_withdraw"></a>![Method: ](https://apidocs.io/img/method.png ".RecipientsController.createWithdraw") createWithdraw
-
-> TODO: Add a method description
-
-
-```javascript
-function createWithdraw(recipientId, request, callback)
-```
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| recipientId |  ``` Required ```  | TODO: Add a parameter description |
-| request |  ``` Required ```  | TODO: Add a parameter description |
-
-
-
-#### Example Usage
-
-```javascript
-
-    var recipientId = recipient_id;
-    var request = new CreateWithdrawRequest({"key":"value"});
-
-    controller.createWithdraw(recipientId, request, function(error, response, context) {
-
-    
-    });
-```
-
-
-
-### <a name="update_automatic_anticipation_settings"></a>![Method: ](https://apidocs.io/img/method.png ".RecipientsController.updateAutomaticAnticipationSettings") updateAutomaticAnticipationSettings
-
-> Updates recipient metadata
-
-
-```javascript
-function updateAutomaticAnticipationSettings(recipientId, request, idempotencyKey, callback)
-```
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| recipientId |  ``` Required ```  | Recipient id |
-| request |  ``` Required ```  | Metadata |
-| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
-
-
-
-#### Example Usage
-
-```javascript
-
-    var recipientId = recipient_id;
-    var request = new UpdateAutomaticAnticipationSettingsRequest({"key":"value"});
-    var idempotencyKey = 'idempotency-key';
-
-    controller.updateAutomaticAnticipationSettings(recipientId, request, idempotencyKey, function(error, response, context) {
-
-    
-    });
-```
-
-
-
-### <a name="get_anticipation"></a>![Method: ](https://apidocs.io/img/method.png ".RecipientsController.getAnticipation") getAnticipation
-
-> Gets an anticipation
-
-
-```javascript
-function getAnticipation(recipientId, anticipationId, callback)
-```
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| recipientId |  ``` Required ```  | Recipient id |
-| anticipationId |  ``` Required ```  | Anticipation id |
-
-
-
-#### Example Usage
-
-```javascript
-
-    var recipientId = recipient_id;
-    var anticipationId = anticipation_id;
-
-    controller.getAnticipation(recipientId, anticipationId, function(error, response, context) {
-
-    
-    });
-```
-
-
-
-### <a name="update_recipient_transfer_settings"></a>![Method: ](https://apidocs.io/img/method.png ".RecipientsController.updateRecipientTransferSettings") updateRecipientTransferSettings
-
-> TODO: Add a method description
-
-
-```javascript
-function updateRecipientTransferSettings(recipientId, request, idempotencyKey, callback)
-```
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| recipientId |  ``` Required ```  | Recipient Identificator |
-| request |  ``` Required ```  | TODO: Add a parameter description |
-| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
-
-
-
-#### Example Usage
-
-```javascript
-
-    var recipientId = recipient_id;
-    var request = new UpdateTransferSettingsRequest({"key":"value"});
-    var idempotencyKey = 'idempotency-key';
-
-    controller.updateRecipientTransferSettings(recipientId, request, idempotencyKey, function(error, response, context) {
-
-    
-    });
-```
-
-
-
-### <a name="get_anticipations"></a>![Method: ](https://apidocs.io/img/method.png ".RecipientsController.getAnticipations") getAnticipations
-
-> Retrieves a paginated list of anticipations from a recipient
-
-
-```javascript
-function getAnticipations(recipientId, page, size, status, timeframe, paymentDateSince, paymentDateUntil, createdSince, createdUntil, callback)
-```
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| recipientId |  ``` Required ```  | Recipient id |
-| page |  ``` Optional ```  | Page number |
-| size |  ``` Optional ```  | Page size |
-| status |  ``` Optional ```  | Filter for anticipation status |
-| timeframe |  ``` Optional ```  | Filter for anticipation timeframe |
-| paymentDateSince |  ``` Optional ```  | Filter for start range for anticipation payment date |
-| paymentDateUntil |  ``` Optional ```  | Filter for end range for anticipation payment date |
-| createdSince |  ``` Optional ```  | Filter for start range for anticipation creation date |
-| createdUntil |  ``` Optional ```  | Filter for end range for anticipation creation date |
-
-
-
-#### Example Usage
-
-```javascript
-
-    var recipientId = recipient_id;
-    var page = 223;
-    var size = 223;
-    var status = 'status';
-    var timeframe = 'timeframe';
-    var paymentDateSince = date("D M d, Y G:i");
-    var paymentDateUntil = date("D M d, Y G:i");
-    var createdSince = date("D M d, Y G:i");
-    var createdUntil = date("D M d, Y G:i");
-
-    controller.getAnticipations(recipientId, page, size, status, timeframe, paymentDateSince, paymentDateUntil, createdSince, createdUntil, function(error, response, context) {
-
-    
-    });
-```
-
-
-
-### <a name="get_recipient"></a>![Method: ](https://apidocs.io/img/method.png ".RecipientsController.getRecipient") getRecipient
-
-> Retrieves recipient information
-
-
-```javascript
-function getRecipient(recipientId, callback)
-```
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| recipientId |  ``` Required ```  | Recipiend id |
-
-
-
-#### Example Usage
-
-```javascript
-
-    var recipientId = recipient_id;
-
-    controller.getRecipient(recipientId, function(error, response, context) {
-
-    
-    });
-```
-
-
-
-### <a name="get_balance"></a>![Method: ](https://apidocs.io/img/method.png ".RecipientsController.getBalance") getBalance
-
-> Get balance information for a recipient
-
-
-```javascript
-function getBalance(recipientId, callback)
-```
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| recipientId |  ``` Required ```  | Recipient id |
-
-
-
-#### Example Usage
-
-```javascript
-
-    var recipientId = recipient_id;
-
-    controller.getBalance(recipientId, function(error, response, context) {
-
-    
-    });
-```
-
-
-
-### <a name="get_withdrawals"></a>![Method: ](https://apidocs.io/img/method.png ".RecipientsController.getWithdrawals") getWithdrawals
-
-> Gets a paginated list of transfers for the recipient
-
-
-```javascript
-function getWithdrawals(recipientId, page, size, status, createdSince, createdUntil, callback)
-```
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| recipientId |  ``` Required ```  | TODO: Add a parameter description |
-| page |  ``` Optional ```  | TODO: Add a parameter description |
-| size |  ``` Optional ```  | TODO: Add a parameter description |
-| status |  ``` Optional ```  | TODO: Add a parameter description |
-| createdSince |  ``` Optional ```  | TODO: Add a parameter description |
-| createdUntil |  ``` Optional ```  | TODO: Add a parameter description |
-
-
-
-#### Example Usage
-
-```javascript
-
-    var recipientId = recipient_id;
-    var page = 223;
-    var size = 223;
-    var status = 'status';
-    var createdSince = date("D M d, Y G:i");
-    var createdUntil = date("D M d, Y G:i");
-
-    controller.getWithdrawals(recipientId, page, size, status, createdSince, createdUntil, function(error, response, context) {
-
-    
-    });
-```
-
-
-
-### <a name="create_transfer"></a>![Method: ](https://apidocs.io/img/method.png ".RecipientsController.createTransfer") createTransfer
-
-> Creates a transfer for a recipient
-
-
-```javascript
-function createTransfer(recipientId, request, idempotencyKey, callback)
-```
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| recipientId |  ``` Required ```  | Recipient Id |
-| request |  ``` Required ```  | Transfer data |
-| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
-
-
-
-#### Example Usage
-
-```javascript
-
-    var recipientId = recipient_id;
-    var request = new CreateTransferRequest({"key":"value"});
-    var idempotencyKey = 'idempotency-key';
-
-    controller.createTransfer(recipientId, request, idempotencyKey, function(error, response, context) {
-
-    
-    });
-```
-
-
-
-### <a name="create_recipient"></a>![Method: ](https://apidocs.io/img/method.png ".RecipientsController.createRecipient") createRecipient
-
-> Creates a new recipient
-
-
-```javascript
-function createRecipient(request, idempotencyKey, callback)
-```
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| request |  ``` Required ```  | Recipient data |
-| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
-
-
-
-#### Example Usage
-
-```javascript
-
-    var request = new CreateRecipientRequest({"key":"value"});
-    var idempotencyKey = 'idempotency-key';
-
-    controller.createRecipient(request, idempotencyKey, function(error, response, context) {
-
-    
-    });
-```
-
-
-
-### <a name="get_recipient_by_code"></a>![Method: ](https://apidocs.io/img/method.png ".RecipientsController.getRecipientByCode") getRecipientByCode
-
-> Retrieves recipient information
-
-
-```javascript
-function getRecipientByCode(code, callback)
-```
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| code |  ``` Required ```  | Recipient code |
-
-
-
-#### Example Usage
-
-```javascript
-
-    var code = 'code';
-
-    controller.getRecipientByCode(code, function(error, response, context) {
-
-    
-    });
-```
-
-
-
-### <a name="get_default_recipient"></a>![Method: ](https://apidocs.io/img/method.png ".RecipientsController.getDefaultRecipient") getDefaultRecipient
-
-> TODO: Add a method description
-
-
-```javascript
-function getDefaultRecipient(callback)
-```
-
-#### Example Usage
-
-```javascript
-
-
-    controller.getDefaultRecipient(function(error, response, context) {
-
-    
-    });
-```
-
-
-
-[Back to List of Controllers](#list_of_controllers)
-
 ## <a name="charges_controller"></a>![Class: ](https://apidocs.io/img/class.png ".ChargesController") ChargesController
 
 ### Get singleton instance
@@ -3797,6 +3082,40 @@ function updateChargeMetadata(chargeId, request, idempotencyKey, callback)
     var idempotencyKey = 'idempotency-key';
 
     controller.updateChargeMetadata(chargeId, request, idempotencyKey, function(error, response, context) {
+
+    
+    });
+```
+
+
+
+### <a name="capture_charge"></a>![Method: ](https://apidocs.io/img/method.png ".ChargesController.captureCharge") captureCharge
+
+> Captures a charge
+
+
+```javascript
+function captureCharge(chargeId, request, idempotencyKey, callback)
+```
+#### Parameters
+
+| Parameter | Tags | Description |
+|-----------|------|-------------|
+| chargeId |  ``` Required ```  | Charge id |
+| request |  ``` Optional ```  | Request for capturing a charge |
+| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
+
+
+
+#### Example Usage
+
+```javascript
+
+    var chargeId = charge_id;
+    var request = new CreateCaptureChargeRequest({"key":"value"});
+    var idempotencyKey = 'idempotency-key';
+
+    controller.captureCharge(chargeId, request, idempotencyKey, function(error, response, context) {
 
     
     });
@@ -3861,8 +3180,8 @@ function getChargeTransactions(chargeId, page, size, callback)
 ```javascript
 
     var chargeId = charge_id;
-    var page = 223;
-    var size = 223;
+    var page = 192;
+    var size = 192;
 
     controller.getChargeTransactions(chargeId, page, size, function(error, response, context) {
 
@@ -3934,8 +3253,8 @@ function getCharges(page, size, code, status, paymentMethod, customerId, orderId
 
 ```javascript
 
-    var page = 223;
-    var size = 223;
+    var page = 192;
+    var size = 192;
     var code = 'code';
     var status = 'status';
     var paymentMethod = payment_method;
@@ -3945,40 +3264,6 @@ function getCharges(page, size, code, status, paymentMethod, customerId, orderId
     var createdUntil = date("D M d, Y G:i");
 
     controller.getCharges(page, size, code, status, paymentMethod, customerId, orderId, createdSince, createdUntil, function(error, response, context) {
-
-    
-    });
-```
-
-
-
-### <a name="capture_charge"></a>![Method: ](https://apidocs.io/img/method.png ".ChargesController.captureCharge") captureCharge
-
-> Captures a charge
-
-
-```javascript
-function captureCharge(chargeId, request, idempotencyKey, callback)
-```
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| chargeId |  ``` Required ```  | Charge id |
-| request |  ``` Optional ```  | Request for capturing a charge |
-| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
-
-
-
-#### Example Usage
-
-```javascript
-
-    var chargeId = charge_id;
-    var request = new CreateCaptureChargeRequest({"key":"value"});
-    var idempotencyKey = 'idempotency-key';
-
-    controller.captureCharge(chargeId, request, idempotencyKey, function(error, response, context) {
 
     
     });
@@ -4312,6 +3597,720 @@ function getTransfers(callback)
 
 [Back to List of Controllers](#list_of_controllers)
 
+## <a name="recipients_controller"></a>![Class: ](https://apidocs.io/img/class.png ".RecipientsController") RecipientsController
+
+### Get singleton instance
+
+The singleton instance of the ``` RecipientsController ``` class can be accessed from the API Client.
+
+```javascript
+var controller = lib.RecipientsController;
+```
+
+### <a name="get_transfer"></a>![Method: ](https://apidocs.io/img/method.png ".RecipientsController.getTransfer") getTransfer
+
+> Gets a transfer
+
+
+```javascript
+function getTransfer(recipientId, transferId, callback)
+```
+#### Parameters
+
+| Parameter | Tags | Description |
+|-----------|------|-------------|
+| recipientId |  ``` Required ```  | Recipient id |
+| transferId |  ``` Required ```  | Transfer id |
+
+
+
+#### Example Usage
+
+```javascript
+
+    var recipientId = recipient_id;
+    var transferId = transfer_id;
+
+    controller.getTransfer(recipientId, transferId, function(error, response, context) {
+
+    
+    });
+```
+
+
+
+### <a name="update_recipient"></a>![Method: ](https://apidocs.io/img/method.png ".RecipientsController.updateRecipient") updateRecipient
+
+> Updates a recipient
+
+
+```javascript
+function updateRecipient(recipientId, request, idempotencyKey, callback)
+```
+#### Parameters
+
+| Parameter | Tags | Description |
+|-----------|------|-------------|
+| recipientId |  ``` Required ```  | Recipient id |
+| request |  ``` Required ```  | Recipient data |
+| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
+
+
+
+#### Example Usage
+
+```javascript
+
+    var recipientId = recipient_id;
+    var request = new UpdateRecipientRequest({"key":"value"});
+    var idempotencyKey = 'idempotency-key';
+
+    controller.updateRecipient(recipientId, request, idempotencyKey, function(error, response, context) {
+
+    
+    });
+```
+
+
+
+### <a name="create_anticipation"></a>![Method: ](https://apidocs.io/img/method.png ".RecipientsController.createAnticipation") createAnticipation
+
+> Creates an anticipation
+
+
+```javascript
+function createAnticipation(recipientId, request, idempotencyKey, callback)
+```
+#### Parameters
+
+| Parameter | Tags | Description |
+|-----------|------|-------------|
+| recipientId |  ``` Required ```  | Recipient id |
+| request |  ``` Required ```  | Anticipation data |
+| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
+
+
+
+#### Example Usage
+
+```javascript
+
+    var recipientId = recipient_id;
+    var request = new CreateAnticipationRequest({"key":"value"});
+    var idempotencyKey = 'idempotency-key';
+
+    controller.createAnticipation(recipientId, request, idempotencyKey, function(error, response, context) {
+
+    
+    });
+```
+
+
+
+### <a name="get_anticipation_limits"></a>![Method: ](https://apidocs.io/img/method.png ".RecipientsController.getAnticipationLimits") getAnticipationLimits
+
+> Gets the anticipation limits for a recipient
+
+
+```javascript
+function getAnticipationLimits(recipientId, timeframe, paymentDate, callback)
+```
+#### Parameters
+
+| Parameter | Tags | Description |
+|-----------|------|-------------|
+| recipientId |  ``` Required ```  | Recipient id |
+| timeframe |  ``` Required ```  | Timeframe |
+| paymentDate |  ``` Required ```  | Anticipation payment date |
+
+
+
+#### Example Usage
+
+```javascript
+
+    var recipientId = recipient_id;
+    var timeframe = 'timeframe';
+    var paymentDate = date("D M d, Y G:i");
+
+    controller.getAnticipationLimits(recipientId, timeframe, paymentDate, function(error, response, context) {
+
+    
+    });
+```
+
+
+
+### <a name="get_recipients"></a>![Method: ](https://apidocs.io/img/method.png ".RecipientsController.getRecipients") getRecipients
+
+> Retrieves paginated recipients information
+
+
+```javascript
+function getRecipients(page, size, callback)
+```
+#### Parameters
+
+| Parameter | Tags | Description |
+|-----------|------|-------------|
+| page |  ``` Optional ```  | Page number |
+| size |  ``` Optional ```  | Page size |
+
+
+
+#### Example Usage
+
+```javascript
+
+    var page = 192;
+    var size = 192;
+
+    controller.getRecipients(page, size, function(error, response, context) {
+
+    
+    });
+```
+
+
+
+### <a name="get_withdraw_by_id"></a>![Method: ](https://apidocs.io/img/method.png ".RecipientsController.getWithdrawById") getWithdrawById
+
+> TODO: Add a method description
+
+
+```javascript
+function getWithdrawById(recipientId, withdrawalId, callback)
+```
+#### Parameters
+
+| Parameter | Tags | Description |
+|-----------|------|-------------|
+| recipientId |  ``` Required ```  | TODO: Add a parameter description |
+| withdrawalId |  ``` Required ```  | TODO: Add a parameter description |
+
+
+
+#### Example Usage
+
+```javascript
+
+    var recipientId = recipient_id;
+    var withdrawalId = withdrawal_id;
+
+    controller.getWithdrawById(recipientId, withdrawalId, function(error, response, context) {
+
+    
+    });
+```
+
+
+
+### <a name="update_recipient_default_bank_account"></a>![Method: ](https://apidocs.io/img/method.png ".RecipientsController.updateRecipientDefaultBankAccount") updateRecipientDefaultBankAccount
+
+> Updates the default bank account from a recipient
+
+
+```javascript
+function updateRecipientDefaultBankAccount(recipientId, request, idempotencyKey, callback)
+```
+#### Parameters
+
+| Parameter | Tags | Description |
+|-----------|------|-------------|
+| recipientId |  ``` Required ```  | Recipient id |
+| request |  ``` Required ```  | Bank account data |
+| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
+
+
+
+#### Example Usage
+
+```javascript
+
+    var recipientId = recipient_id;
+    var request = new UpdateRecipientBankAccountRequest({"key":"value"});
+    var idempotencyKey = 'idempotency-key';
+
+    controller.updateRecipientDefaultBankAccount(recipientId, request, idempotencyKey, function(error, response, context) {
+
+    
+    });
+```
+
+
+
+### <a name="update_recipient_metadata"></a>![Method: ](https://apidocs.io/img/method.png ".RecipientsController.updateRecipientMetadata") updateRecipientMetadata
+
+> Updates recipient metadata
+
+
+```javascript
+function updateRecipientMetadata(recipientId, request, idempotencyKey, callback)
+```
+#### Parameters
+
+| Parameter | Tags | Description |
+|-----------|------|-------------|
+| recipientId |  ``` Required ```  | Recipient id |
+| request |  ``` Required ```  | Metadata |
+| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
+
+
+
+#### Example Usage
+
+```javascript
+
+    var recipientId = recipient_id;
+    var request = new UpdateMetadataRequest({"key":"value"});
+    var idempotencyKey = 'idempotency-key';
+
+    controller.updateRecipientMetadata(recipientId, request, idempotencyKey, function(error, response, context) {
+
+    
+    });
+```
+
+
+
+### <a name="get_transfers"></a>![Method: ](https://apidocs.io/img/method.png ".RecipientsController.getTransfers") getTransfers
+
+> Gets a paginated list of transfers for the recipient
+
+
+```javascript
+function getTransfers(recipientId, page, size, status, createdSince, createdUntil, callback)
+```
+#### Parameters
+
+| Parameter | Tags | Description |
+|-----------|------|-------------|
+| recipientId |  ``` Required ```  | Recipient id |
+| page |  ``` Optional ```  | Page number |
+| size |  ``` Optional ```  | Page size |
+| status |  ``` Optional ```  | Filter for transfer status |
+| createdSince |  ``` Optional ```  | Filter for start range of transfer creation date |
+| createdUntil |  ``` Optional ```  | Filter for end range of transfer creation date |
+
+
+
+#### Example Usage
+
+```javascript
+
+    var recipientId = recipient_id;
+    var page = 192;
+    var size = 192;
+    var status = 'status';
+    var createdSince = date("D M d, Y G:i");
+    var createdUntil = date("D M d, Y G:i");
+
+    controller.getTransfers(recipientId, page, size, status, createdSince, createdUntil, function(error, response, context) {
+
+    
+    });
+```
+
+
+
+### <a name="create_withdraw"></a>![Method: ](https://apidocs.io/img/method.png ".RecipientsController.createWithdraw") createWithdraw
+
+> TODO: Add a method description
+
+
+```javascript
+function createWithdraw(recipientId, request, callback)
+```
+#### Parameters
+
+| Parameter | Tags | Description |
+|-----------|------|-------------|
+| recipientId |  ``` Required ```  | TODO: Add a parameter description |
+| request |  ``` Required ```  | TODO: Add a parameter description |
+
+
+
+#### Example Usage
+
+```javascript
+
+    var recipientId = recipient_id;
+    var request = new CreateWithdrawRequest({"key":"value"});
+
+    controller.createWithdraw(recipientId, request, function(error, response, context) {
+
+    
+    });
+```
+
+
+
+### <a name="update_automatic_anticipation_settings"></a>![Method: ](https://apidocs.io/img/method.png ".RecipientsController.updateAutomaticAnticipationSettings") updateAutomaticAnticipationSettings
+
+> Updates recipient metadata
+
+
+```javascript
+function updateAutomaticAnticipationSettings(recipientId, request, idempotencyKey, callback)
+```
+#### Parameters
+
+| Parameter | Tags | Description |
+|-----------|------|-------------|
+| recipientId |  ``` Required ```  | Recipient id |
+| request |  ``` Required ```  | Metadata |
+| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
+
+
+
+#### Example Usage
+
+```javascript
+
+    var recipientId = recipient_id;
+    var request = new UpdateAutomaticAnticipationSettingsRequest({"key":"value"});
+    var idempotencyKey = 'idempotency-key';
+
+    controller.updateAutomaticAnticipationSettings(recipientId, request, idempotencyKey, function(error, response, context) {
+
+    
+    });
+```
+
+
+
+### <a name="get_anticipation"></a>![Method: ](https://apidocs.io/img/method.png ".RecipientsController.getAnticipation") getAnticipation
+
+> Gets an anticipation
+
+
+```javascript
+function getAnticipation(recipientId, anticipationId, callback)
+```
+#### Parameters
+
+| Parameter | Tags | Description |
+|-----------|------|-------------|
+| recipientId |  ``` Required ```  | Recipient id |
+| anticipationId |  ``` Required ```  | Anticipation id |
+
+
+
+#### Example Usage
+
+```javascript
+
+    var recipientId = recipient_id;
+    var anticipationId = anticipation_id;
+
+    controller.getAnticipation(recipientId, anticipationId, function(error, response, context) {
+
+    
+    });
+```
+
+
+
+### <a name="update_recipient_transfer_settings"></a>![Method: ](https://apidocs.io/img/method.png ".RecipientsController.updateRecipientTransferSettings") updateRecipientTransferSettings
+
+> TODO: Add a method description
+
+
+```javascript
+function updateRecipientTransferSettings(recipientId, request, idempotencyKey, callback)
+```
+#### Parameters
+
+| Parameter | Tags | Description |
+|-----------|------|-------------|
+| recipientId |  ``` Required ```  | Recipient Identificator |
+| request |  ``` Required ```  | TODO: Add a parameter description |
+| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
+
+
+
+#### Example Usage
+
+```javascript
+
+    var recipientId = recipient_id;
+    var request = new UpdateTransferSettingsRequest({"key":"value"});
+    var idempotencyKey = 'idempotency-key';
+
+    controller.updateRecipientTransferSettings(recipientId, request, idempotencyKey, function(error, response, context) {
+
+    
+    });
+```
+
+
+
+### <a name="get_anticipations"></a>![Method: ](https://apidocs.io/img/method.png ".RecipientsController.getAnticipations") getAnticipations
+
+> Retrieves a paginated list of anticipations from a recipient
+
+
+```javascript
+function getAnticipations(recipientId, page, size, status, timeframe, paymentDateSince, paymentDateUntil, createdSince, createdUntil, callback)
+```
+#### Parameters
+
+| Parameter | Tags | Description |
+|-----------|------|-------------|
+| recipientId |  ``` Required ```  | Recipient id |
+| page |  ``` Optional ```  | Page number |
+| size |  ``` Optional ```  | Page size |
+| status |  ``` Optional ```  | Filter for anticipation status |
+| timeframe |  ``` Optional ```  | Filter for anticipation timeframe |
+| paymentDateSince |  ``` Optional ```  | Filter for start range for anticipation payment date |
+| paymentDateUntil |  ``` Optional ```  | Filter for end range for anticipation payment date |
+| createdSince |  ``` Optional ```  | Filter for start range for anticipation creation date |
+| createdUntil |  ``` Optional ```  | Filter for end range for anticipation creation date |
+
+
+
+#### Example Usage
+
+```javascript
+
+    var recipientId = recipient_id;
+    var page = 192;
+    var size = 192;
+    var status = 'status';
+    var timeframe = 'timeframe';
+    var paymentDateSince = date("D M d, Y G:i");
+    var paymentDateUntil = date("D M d, Y G:i");
+    var createdSince = date("D M d, Y G:i");
+    var createdUntil = date("D M d, Y G:i");
+
+    controller.getAnticipations(recipientId, page, size, status, timeframe, paymentDateSince, paymentDateUntil, createdSince, createdUntil, function(error, response, context) {
+
+    
+    });
+```
+
+
+
+### <a name="get_recipient"></a>![Method: ](https://apidocs.io/img/method.png ".RecipientsController.getRecipient") getRecipient
+
+> Retrieves recipient information
+
+
+```javascript
+function getRecipient(recipientId, callback)
+```
+#### Parameters
+
+| Parameter | Tags | Description |
+|-----------|------|-------------|
+| recipientId |  ``` Required ```  | Recipiend id |
+
+
+
+#### Example Usage
+
+```javascript
+
+    var recipientId = recipient_id;
+
+    controller.getRecipient(recipientId, function(error, response, context) {
+
+    
+    });
+```
+
+
+
+### <a name="get_withdrawals"></a>![Method: ](https://apidocs.io/img/method.png ".RecipientsController.getWithdrawals") getWithdrawals
+
+> Gets a paginated list of transfers for the recipient
+
+
+```javascript
+function getWithdrawals(recipientId, page, size, status, createdSince, createdUntil, callback)
+```
+#### Parameters
+
+| Parameter | Tags | Description |
+|-----------|------|-------------|
+| recipientId |  ``` Required ```  | TODO: Add a parameter description |
+| page |  ``` Optional ```  | TODO: Add a parameter description |
+| size |  ``` Optional ```  | TODO: Add a parameter description |
+| status |  ``` Optional ```  | TODO: Add a parameter description |
+| createdSince |  ``` Optional ```  | TODO: Add a parameter description |
+| createdUntil |  ``` Optional ```  | TODO: Add a parameter description |
+
+
+
+#### Example Usage
+
+```javascript
+
+    var recipientId = recipient_id;
+    var page = 192;
+    var size = 192;
+    var status = 'status';
+    var createdSince = date("D M d, Y G:i");
+    var createdUntil = date("D M d, Y G:i");
+
+    controller.getWithdrawals(recipientId, page, size, status, createdSince, createdUntil, function(error, response, context) {
+
+    
+    });
+```
+
+
+
+### <a name="get_balance"></a>![Method: ](https://apidocs.io/img/method.png ".RecipientsController.getBalance") getBalance
+
+> Get balance information for a recipient
+
+
+```javascript
+function getBalance(recipientId, callback)
+```
+#### Parameters
+
+| Parameter | Tags | Description |
+|-----------|------|-------------|
+| recipientId |  ``` Required ```  | Recipient id |
+
+
+
+#### Example Usage
+
+```javascript
+
+    var recipientId = recipient_id;
+
+    controller.getBalance(recipientId, function(error, response, context) {
+
+    
+    });
+```
+
+
+
+### <a name="create_transfer"></a>![Method: ](https://apidocs.io/img/method.png ".RecipientsController.createTransfer") createTransfer
+
+> Creates a transfer for a recipient
+
+
+```javascript
+function createTransfer(recipientId, request, idempotencyKey, callback)
+```
+#### Parameters
+
+| Parameter | Tags | Description |
+|-----------|------|-------------|
+| recipientId |  ``` Required ```  | Recipient Id |
+| request |  ``` Required ```  | Transfer data |
+| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
+
+
+
+#### Example Usage
+
+```javascript
+
+    var recipientId = recipient_id;
+    var request = new CreateTransferRequest({"key":"value"});
+    var idempotencyKey = 'idempotency-key';
+
+    controller.createTransfer(recipientId, request, idempotencyKey, function(error, response, context) {
+
+    
+    });
+```
+
+
+
+### <a name="create_recipient"></a>![Method: ](https://apidocs.io/img/method.png ".RecipientsController.createRecipient") createRecipient
+
+> Creates a new recipient
+
+
+```javascript
+function createRecipient(request, idempotencyKey, callback)
+```
+#### Parameters
+
+| Parameter | Tags | Description |
+|-----------|------|-------------|
+| request |  ``` Required ```  | Recipient data |
+| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
+
+
+
+#### Example Usage
+
+```javascript
+
+    var request = new CreateRecipientRequest({"key":"value"});
+    var idempotencyKey = 'idempotency-key';
+
+    controller.createRecipient(request, idempotencyKey, function(error, response, context) {
+
+    
+    });
+```
+
+
+
+### <a name="get_recipient_by_code"></a>![Method: ](https://apidocs.io/img/method.png ".RecipientsController.getRecipientByCode") getRecipientByCode
+
+> Retrieves recipient information
+
+
+```javascript
+function getRecipientByCode(code, callback)
+```
+#### Parameters
+
+| Parameter | Tags | Description |
+|-----------|------|-------------|
+| code |  ``` Required ```  | Recipient code |
+
+
+
+#### Example Usage
+
+```javascript
+
+    var code = 'code';
+
+    controller.getRecipientByCode(code, function(error, response, context) {
+
+    
+    });
+```
+
+
+
+### <a name="get_default_recipient"></a>![Method: ](https://apidocs.io/img/method.png ".RecipientsController.getDefaultRecipient") getDefaultRecipient
+
+> TODO: Add a method description
+
+
+```javascript
+function getDefaultRecipient(callback)
+```
+
+#### Example Usage
+
+```javascript
+
+
+    controller.getDefaultRecipient(function(error, response, context) {
+
+    
+    });
+```
+
+
+
+[Back to List of Controllers](#list_of_controllers)
+
 ## <a name="tokens_controller"></a>![Class: ](https://apidocs.io/img/class.png ".TokensController") TokensController
 
 ### Get singleton instance
@@ -4385,226 +4384,6 @@ function getToken(id, publicKey, callback)
     var publicKey = public_key;
 
     controller.getToken(id, publicKey, function(error, response, context) {
-
-    
-    });
-```
-
-
-
-[Back to List of Controllers](#list_of_controllers)
-
-## <a name="sellers_controller"></a>![Class: ](https://apidocs.io/img/class.png ".SellersController") SellersController
-
-### Get singleton instance
-
-The singleton instance of the ``` SellersController ``` class can be accessed from the API Client.
-
-```javascript
-var controller = lib.SellersController;
-```
-
-### <a name="create_seller"></a>![Method: ](https://apidocs.io/img/method.png ".SellersController.createSeller") createSeller
-
-> TODO: Add a method description
-
-
-```javascript
-function createSeller(request, idempotencyKey, callback)
-```
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| request |  ``` Required ```  | Seller Model |
-| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
-
-
-
-#### Example Usage
-
-```javascript
-
-    var request = new CreateSellerRequest({"key":"value"});
-    var idempotencyKey = 'idempotency-key';
-
-    controller.createSeller(request, idempotencyKey, function(error, response, context) {
-
-    
-    });
-```
-
-
-
-### <a name="update_seller_metadata"></a>![Method: ](https://apidocs.io/img/method.png ".SellersController.updateSellerMetadata") updateSellerMetadata
-
-> TODO: Add a method description
-
-
-```javascript
-function updateSellerMetadata(sellerId, request, idempotencyKey, callback)
-```
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| sellerId |  ``` Required ```  | Seller Id |
-| request |  ``` Required ```  | Request for updating the charge metadata |
-| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
-
-
-
-#### Example Usage
-
-```javascript
-
-    var sellerId = seller_id;
-    var request = new UpdateMetadataRequest({"key":"value"});
-    var idempotencyKey = 'idempotency-key';
-
-    controller.updateSellerMetadata(sellerId, request, idempotencyKey, function(error, response, context) {
-
-    
-    });
-```
-
-
-
-### <a name="update_seller"></a>![Method: ](https://apidocs.io/img/method.png ".SellersController.updateSeller") updateSeller
-
-> TODO: Add a method description
-
-
-```javascript
-function updateSeller(id, request, idempotencyKey, callback)
-```
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| id |  ``` Required ```  | TODO: Add a parameter description |
-| request |  ``` Required ```  | Update Seller model |
-| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
-
-
-
-#### Example Usage
-
-```javascript
-
-    var id = 'id';
-    var request = new UpdateSellerRequest({"key":"value"});
-    var idempotencyKey = 'idempotency-key';
-
-    controller.updateSeller(id, request, idempotencyKey, function(error, response, context) {
-
-    
-    });
-```
-
-
-
-### <a name="delete_seller"></a>![Method: ](https://apidocs.io/img/method.png ".SellersController.deleteSeller") deleteSeller
-
-> TODO: Add a method description
-
-
-```javascript
-function deleteSeller(sellerId, idempotencyKey, callback)
-```
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| sellerId |  ``` Required ```  | Seller Id |
-| idempotencyKey |  ``` Optional ```  | TODO: Add a parameter description |
-
-
-
-#### Example Usage
-
-```javascript
-
-    var sellerId = 'sellerId';
-    var idempotencyKey = 'idempotency-key';
-
-    controller.deleteSeller(sellerId, idempotencyKey, function(error, response, context) {
-
-    
-    });
-```
-
-
-
-### <a name="get_seller_by_id"></a>![Method: ](https://apidocs.io/img/method.png ".SellersController.getSellerById") getSellerById
-
-> TODO: Add a method description
-
-
-```javascript
-function getSellerById(id, callback)
-```
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| id |  ``` Required ```  | Seller Id |
-
-
-
-#### Example Usage
-
-```javascript
-
-    var id = 'id';
-
-    controller.getSellerById(id, function(error, response, context) {
-
-    
-    });
-```
-
-
-
-### <a name="get_sellers"></a>![Method: ](https://apidocs.io/img/method.png ".SellersController.getSellers") getSellers
-
-> TODO: Add a method description
-
-
-```javascript
-function getSellers(page, size, name, document, code, status, type, createdSince, createdUntil, callback)
-```
-#### Parameters
-
-| Parameter | Tags | Description |
-|-----------|------|-------------|
-| page |  ``` Optional ```  | Page number |
-| size |  ``` Optional ```  | Page size |
-| name |  ``` Optional ```  | TODO: Add a parameter description |
-| document |  ``` Optional ```  | TODO: Add a parameter description |
-| code |  ``` Optional ```  | TODO: Add a parameter description |
-| status |  ``` Optional ```  | TODO: Add a parameter description |
-| type |  ``` Optional ```  | TODO: Add a parameter description |
-| createdSince |  ``` Optional ```  | TODO: Add a parameter description |
-| createdUntil |  ``` Optional ```  | TODO: Add a parameter description |
-
-
-
-#### Example Usage
-
-```javascript
-
-    var page = 59;
-    var size = 59;
-    var name = 'name';
-    var document = 'document';
-    var code = 'code';
-    var status = 'status';
-    var type = 'type';
-    var createdSince = date("D M d, Y G:i");
-    var createdUntil = date("D M d, Y G:i");
-
-    controller.getSellers(page, size, name, document, code, status, type, createdSince, createdUntil, function(error, response, context) {
 
     
     });

--- a/lib/Controllers/ChargesController.js
+++ b/lib/Controllers/ChargesController.js
@@ -46,13 +46,81 @@ class ChargesController {
             accept: 'application/json',
             'content-type': 'application/json; charset=utf-8',
             'idempotency-key': idempotencyKey,
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
         const _options = {
             queryUrl: _queryUrl,
             method: 'PATCH',
+            headers: _headers,
+            body: _apiHelper.jsonSerialize(request),
+            username: _configuration.basicAuthUserName,
+            password: _configuration.basicAuthPassword,
+        };
+
+        // build the response processing.
+        return new Promise((_fulfill, _reject) => {
+            _request(_options, (_error, _response, _context) => {
+                let errorResponse;
+                if (_error) {
+                    errorResponse = _baseController.validateResponse(_context);
+                    _callback(errorResponse.error, errorResponse.response, errorResponse.context);
+                    _reject(errorResponse.error);
+                } else if (_response.statusCode >= 200 && _response.statusCode <= 206) {
+                    let parsed = JSON.parse(_response.body);
+                    parsed = _baseController.getObjectMapper().mapObject(parsed, 'GetChargeResponse');
+                    _callback(null, parsed, _context);
+                    _fulfill(parsed);
+                } else {
+                    errorResponse = _baseController.validateResponse(_context);
+                    _callback(errorResponse.error, errorResponse.response, errorResponse.context);
+                    _reject(errorResponse.error);
+                }
+            });
+        });
+    }
+    /**
+     * Captures a charge
+     *
+     * @param {string} chargeId Charge id
+     * @param {CreateCaptureChargeRequest} request (optional) Request for capturing a charge
+     * @param {string} idempotencyKey (optional) TODO: type description here
+     *
+     * @callback    The callback function that returns response from the API call
+     *
+     * @returns {Promise}
+     */
+    static captureCharge(chargeId, request, idempotencyKey, callback) {
+        // create empty callback if absent
+        const _callback = typeof callback === 'function' ? callback : () => undefined;
+
+        // prepare query string for API call
+        const _baseUri = _configuration.BASEURI;
+
+        let _pathUrl = '/charges/{charge_id}/capture';
+        // process template parameters
+        _pathUrl = _apiHelper.appendUrlWithTemplateParameters(_pathUrl, {
+            charge_id: { value: chargeId, encode: true },
+        });
+
+        const _queryBuilder = `${_baseUri}${_pathUrl}`;
+
+        // validate and preprocess url
+        const _queryUrl = _apiHelper.cleanUrl(_queryBuilder);
+
+        // prepare headers
+        const _headers = {
+            accept: 'application/json',
+            'content-type': 'application/json; charset=utf-8',
+            'idempotency-key': idempotencyKey,
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
+        };
+
+        // construct the request
+        const _options = {
+            queryUrl: _queryUrl,
+            method: 'POST',
             headers: _headers,
             body: _apiHelper.jsonSerialize(request),
             username: _configuration.basicAuthUserName,
@@ -115,7 +183,7 @@ class ChargesController {
             accept: 'application/json',
             'content-type': 'application/json; charset=utf-8',
             'idempotency-key': idempotencyKey,
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -187,7 +255,7 @@ class ChargesController {
         // prepare headers
         const _headers = {
             accept: 'application/json',
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -255,7 +323,7 @@ class ChargesController {
             accept: 'application/json',
             'content-type': 'application/json; charset=utf-8',
             'idempotency-key': idempotencyKey,
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -346,7 +414,7 @@ class ChargesController {
         // prepare headers
         const _headers = {
             accept: 'application/json',
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -369,74 +437,6 @@ class ChargesController {
                 } else if (_response.statusCode >= 200 && _response.statusCode <= 206) {
                     let parsed = JSON.parse(_response.body);
                     parsed = _baseController.getObjectMapper().mapObject(parsed, 'ListChargesResponse');
-                    _callback(null, parsed, _context);
-                    _fulfill(parsed);
-                } else {
-                    errorResponse = _baseController.validateResponse(_context);
-                    _callback(errorResponse.error, errorResponse.response, errorResponse.context);
-                    _reject(errorResponse.error);
-                }
-            });
-        });
-    }
-    /**
-     * Captures a charge
-     *
-     * @param {string} chargeId Charge id
-     * @param {CreateCaptureChargeRequest} request (optional) Request for capturing a charge
-     * @param {string} idempotencyKey (optional) TODO: type description here
-     *
-     * @callback    The callback function that returns response from the API call
-     *
-     * @returns {Promise}
-     */
-    static captureCharge(chargeId, request, idempotencyKey, callback) {
-        // create empty callback if absent
-        const _callback = typeof callback === 'function' ? callback : () => undefined;
-
-        // prepare query string for API call
-        const _baseUri = _configuration.BASEURI;
-
-        let _pathUrl = '/charges/{charge_id}/capture';
-        // process template parameters
-        _pathUrl = _apiHelper.appendUrlWithTemplateParameters(_pathUrl, {
-            charge_id: { value: chargeId, encode: true },
-        });
-
-        const _queryBuilder = `${_baseUri}${_pathUrl}`;
-
-        // validate and preprocess url
-        const _queryUrl = _apiHelper.cleanUrl(_queryBuilder);
-
-        // prepare headers
-        const _headers = {
-            accept: 'application/json',
-            'content-type': 'application/json; charset=utf-8',
-            'idempotency-key': idempotencyKey,
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
-        };
-
-        // construct the request
-        const _options = {
-            queryUrl: _queryUrl,
-            method: 'POST',
-            headers: _headers,
-            body: _apiHelper.jsonSerialize(request),
-            username: _configuration.basicAuthUserName,
-            password: _configuration.basicAuthPassword,
-        };
-
-        // build the response processing.
-        return new Promise((_fulfill, _reject) => {
-            _request(_options, (_error, _response, _context) => {
-                let errorResponse;
-                if (_error) {
-                    errorResponse = _baseController.validateResponse(_context);
-                    _callback(errorResponse.error, errorResponse.response, errorResponse.context);
-                    _reject(errorResponse.error);
-                } else if (_response.statusCode >= 200 && _response.statusCode <= 206) {
-                    let parsed = JSON.parse(_response.body);
-                    parsed = _baseController.getObjectMapper().mapObject(parsed, 'GetChargeResponse');
                     _callback(null, parsed, _context);
                     _fulfill(parsed);
                 } else {
@@ -481,7 +481,7 @@ class ChargesController {
             accept: 'application/json',
             'content-type': 'application/json; charset=utf-8',
             'idempotency-key': idempotencyKey,
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -545,7 +545,7 @@ class ChargesController {
         // prepare headers
         const _headers = {
             accept: 'application/json',
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -612,7 +612,7 @@ class ChargesController {
         // prepare headers
         const _headers = {
             accept: 'application/json',
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -677,7 +677,7 @@ class ChargesController {
         const _headers = {
             accept: 'application/json',
             'idempotency-key': idempotencyKey,
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -744,7 +744,7 @@ class ChargesController {
             accept: 'application/json',
             'content-type': 'application/json; charset=utf-8',
             'idempotency-key': idempotencyKey,
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -806,7 +806,7 @@ class ChargesController {
             accept: 'application/json',
             'content-type': 'application/json; charset=utf-8',
             'idempotency-key': idempotencyKey,
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -874,7 +874,7 @@ class ChargesController {
             accept: 'application/json',
             'content-type': 'application/json; charset=utf-8',
             'idempotency-key': idempotencyKey,
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request

--- a/lib/Controllers/CustomersController.js
+++ b/lib/Controllers/CustomersController.js
@@ -48,7 +48,7 @@ class CustomersController {
             accept: 'application/json',
             'content-type': 'application/json; charset=utf-8',
             'idempotency-key': idempotencyKey,
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -118,7 +118,7 @@ class CustomersController {
             accept: 'application/json',
             'content-type': 'application/json; charset=utf-8',
             'idempotency-key': idempotencyKey,
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -186,7 +186,7 @@ class CustomersController {
         const _headers = {
             accept: 'application/json',
             'idempotency-key': idempotencyKey,
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -220,23 +220,29 @@ class CustomersController {
         });
     }
     /**
-     * Creates a new customer
+     * Creates a access token for a customer
      *
-     * @param {CreateCustomerRequest} request Request for creating a customer
+     * @param {string} customerId Customer Id
+     * @param {CreateAccessTokenRequest} request Request for creating a access token
      * @param {string} idempotencyKey (optional) TODO: type description here
      *
      * @callback    The callback function that returns response from the API call
      *
      * @returns {Promise}
      */
-    static createCustomer(request, idempotencyKey, callback) {
+    static createAccessToken(customerId, request, idempotencyKey, callback) {
         // create empty callback if absent
         const _callback = typeof callback === 'function' ? callback : () => undefined;
 
         // prepare query string for API call
         const _baseUri = _configuration.BASEURI;
 
-        const _pathUrl = '/customers';
+        let _pathUrl = '/customers/{customer_id}/access-tokens';
+        // process template parameters
+        _pathUrl = _apiHelper.appendUrlWithTemplateParameters(_pathUrl, {
+            customer_id: { value: customerId, encode: true },
+        });
+
         const _queryBuilder = `${_baseUri}${_pathUrl}`;
 
         // validate and preprocess url
@@ -247,7 +253,7 @@ class CustomersController {
             accept: 'application/json',
             'content-type': 'application/json; charset=utf-8',
             'idempotency-key': idempotencyKey,
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -270,7 +276,7 @@ class CustomersController {
                     _reject(errorResponse.error);
                 } else if (_response.statusCode >= 200 && _response.statusCode <= 206) {
                     let parsed = JSON.parse(_response.body);
-                    parsed = _baseController.getObjectMapper().mapObject(parsed, 'GetCustomerResponse');
+                    parsed = _baseController.getObjectMapper().mapObject(parsed, 'GetAccessTokenResponse');
                     _callback(null, parsed, _context);
                     _fulfill(parsed);
                 } else {
@@ -315,7 +321,7 @@ class CustomersController {
             accept: 'application/json',
             'content-type': 'application/json; charset=utf-8',
             'idempotency-key': idempotencyKey,
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -339,6 +345,68 @@ class CustomersController {
                 } else if (_response.statusCode >= 200 && _response.statusCode <= 206) {
                     let parsed = JSON.parse(_response.body);
                     parsed = _baseController.getObjectMapper().mapObject(parsed, 'GetAddressResponse');
+                    _callback(null, parsed, _context);
+                    _fulfill(parsed);
+                } else {
+                    errorResponse = _baseController.validateResponse(_context);
+                    _callback(errorResponse.error, errorResponse.response, errorResponse.context);
+                    _reject(errorResponse.error);
+                }
+            });
+        });
+    }
+    /**
+     * Creates a new customer
+     *
+     * @param {CreateCustomerRequest} request Request for creating a customer
+     * @param {string} idempotencyKey (optional) TODO: type description here
+     *
+     * @callback    The callback function that returns response from the API call
+     *
+     * @returns {Promise}
+     */
+    static createCustomer(request, idempotencyKey, callback) {
+        // create empty callback if absent
+        const _callback = typeof callback === 'function' ? callback : () => undefined;
+
+        // prepare query string for API call
+        const _baseUri = _configuration.BASEURI;
+
+        const _pathUrl = '/customers';
+        const _queryBuilder = `${_baseUri}${_pathUrl}`;
+
+        // validate and preprocess url
+        const _queryUrl = _apiHelper.cleanUrl(_queryBuilder);
+
+        // prepare headers
+        const _headers = {
+            accept: 'application/json',
+            'content-type': 'application/json; charset=utf-8',
+            'idempotency-key': idempotencyKey,
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
+        };
+
+        // construct the request
+        const _options = {
+            queryUrl: _queryUrl,
+            method: 'POST',
+            headers: _headers,
+            body: _apiHelper.jsonSerialize(request),
+            username: _configuration.basicAuthUserName,
+            password: _configuration.basicAuthPassword,
+        };
+
+        // build the response processing.
+        return new Promise((_fulfill, _reject) => {
+            _request(_options, (_error, _response, _context) => {
+                let errorResponse;
+                if (_error) {
+                    errorResponse = _baseController.validateResponse(_context);
+                    _callback(errorResponse.error, errorResponse.response, errorResponse.context);
+                    _reject(errorResponse.error);
+                } else if (_response.statusCode >= 200 && _response.statusCode <= 206) {
+                    let parsed = JSON.parse(_response.body);
+                    parsed = _baseController.getObjectMapper().mapObject(parsed, 'GetCustomerResponse');
                     _callback(null, parsed, _context);
                     _fulfill(parsed);
                 } else {
@@ -379,7 +447,7 @@ class CustomersController {
         // prepare headers
         const _headers = {
             accept: 'application/json',
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -444,7 +512,7 @@ class CustomersController {
         // prepare headers
         const _headers = {
             accept: 'application/json',
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -511,7 +579,7 @@ class CustomersController {
         const _headers = {
             accept: 'application/json',
             'idempotency-key': idempotencyKey,
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -578,7 +646,7 @@ class CustomersController {
             accept: 'application/json',
             'content-type': 'application/json; charset=utf-8',
             'idempotency-key': idempotencyKey,
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -652,7 +720,7 @@ class CustomersController {
         // prepare headers
         const _headers = {
             accept: 'application/json',
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -719,7 +787,7 @@ class CustomersController {
             accept: 'application/json',
             'content-type': 'application/json; charset=utf-8',
             'idempotency-key': idempotencyKey,
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -743,74 +811,6 @@ class CustomersController {
                 } else if (_response.statusCode >= 200 && _response.statusCode <= 206) {
                     let parsed = JSON.parse(_response.body);
                     parsed = _baseController.getObjectMapper().mapObject(parsed, 'GetCustomerResponse');
-                    _callback(null, parsed, _context);
-                    _fulfill(parsed);
-                } else {
-                    errorResponse = _baseController.validateResponse(_context);
-                    _callback(errorResponse.error, errorResponse.response, errorResponse.context);
-                    _reject(errorResponse.error);
-                }
-            });
-        });
-    }
-    /**
-     * Creates a access token for a customer
-     *
-     * @param {string} customerId Customer Id
-     * @param {CreateAccessTokenRequest} request Request for creating a access token
-     * @param {string} idempotencyKey (optional) TODO: type description here
-     *
-     * @callback    The callback function that returns response from the API call
-     *
-     * @returns {Promise}
-     */
-    static createAccessToken(customerId, request, idempotencyKey, callback) {
-        // create empty callback if absent
-        const _callback = typeof callback === 'function' ? callback : () => undefined;
-
-        // prepare query string for API call
-        const _baseUri = _configuration.BASEURI;
-
-        let _pathUrl = '/customers/{customer_id}/access-tokens';
-        // process template parameters
-        _pathUrl = _apiHelper.appendUrlWithTemplateParameters(_pathUrl, {
-            customer_id: { value: customerId, encode: true },
-        });
-
-        const _queryBuilder = `${_baseUri}${_pathUrl}`;
-
-        // validate and preprocess url
-        const _queryUrl = _apiHelper.cleanUrl(_queryBuilder);
-
-        // prepare headers
-        const _headers = {
-            accept: 'application/json',
-            'content-type': 'application/json; charset=utf-8',
-            'idempotency-key': idempotencyKey,
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
-        };
-
-        // construct the request
-        const _options = {
-            queryUrl: _queryUrl,
-            method: 'POST',
-            headers: _headers,
-            body: _apiHelper.jsonSerialize(request),
-            username: _configuration.basicAuthUserName,
-            password: _configuration.basicAuthPassword,
-        };
-
-        // build the response processing.
-        return new Promise((_fulfill, _reject) => {
-            _request(_options, (_error, _response, _context) => {
-                let errorResponse;
-                if (_error) {
-                    errorResponse = _baseController.validateResponse(_context);
-                    _callback(errorResponse.error, errorResponse.response, errorResponse.context);
-                    _reject(errorResponse.error);
-                } else if (_response.statusCode >= 200 && _response.statusCode <= 206) {
-                    let parsed = JSON.parse(_response.body);
-                    parsed = _baseController.getObjectMapper().mapObject(parsed, 'GetAccessTokenResponse');
                     _callback(null, parsed, _context);
                     _fulfill(parsed);
                 } else {
@@ -859,7 +859,7 @@ class CustomersController {
         // prepare headers
         const _headers = {
             accept: 'application/json',
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -930,7 +930,7 @@ class CustomersController {
         // prepare headers
         const _headers = {
             accept: 'application/json',
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -997,7 +997,7 @@ class CustomersController {
         const _headers = {
             accept: 'application/json',
             'idempotency-key': idempotencyKey,
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -1062,7 +1062,7 @@ class CustomersController {
         // prepare headers
         const _headers = {
             accept: 'application/json',
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -1129,7 +1129,7 @@ class CustomersController {
             accept: 'application/json',
             'content-type': 'application/json; charset=utf-8',
             'idempotency-key': idempotencyKey,
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -1197,7 +1197,7 @@ class CustomersController {
         const _headers = {
             accept: 'application/json',
             'idempotency-key': idempotencyKey,
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -1268,7 +1268,7 @@ class CustomersController {
         // prepare headers
         const _headers = {
             accept: 'application/json',
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -1331,7 +1331,7 @@ class CustomersController {
         // prepare headers
         const _headers = {
             accept: 'application/json',
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -1396,7 +1396,7 @@ class CustomersController {
         // prepare headers
         const _headers = {
             accept: 'application/json',
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request

--- a/lib/Controllers/InvoicesController.js
+++ b/lib/Controllers/InvoicesController.js
@@ -13,74 +13,6 @@ const _baseController = require('./BaseController');
 
 class InvoicesController {
     /**
-     * Updates the metadata from an invoice
-     *
-     * @param {string} invoiceId The invoice id
-     * @param {UpdateMetadataRequest} request Request for updating the invoice metadata
-     * @param {string} idempotencyKey (optional) TODO: type description here
-     *
-     * @callback    The callback function that returns response from the API call
-     *
-     * @returns {Promise}
-     */
-    static updateInvoiceMetadata(invoiceId, request, idempotencyKey, callback) {
-        // create empty callback if absent
-        const _callback = typeof callback === 'function' ? callback : () => undefined;
-
-        // prepare query string for API call
-        const _baseUri = _configuration.BASEURI;
-
-        let _pathUrl = '/invoices/{invoice_id}/metadata';
-        // process template parameters
-        _pathUrl = _apiHelper.appendUrlWithTemplateParameters(_pathUrl, {
-            invoice_id: { value: invoiceId, encode: true },
-        });
-
-        const _queryBuilder = `${_baseUri}${_pathUrl}`;
-
-        // validate and preprocess url
-        const _queryUrl = _apiHelper.cleanUrl(_queryBuilder);
-
-        // prepare headers
-        const _headers = {
-            accept: 'application/json',
-            'content-type': 'application/json; charset=utf-8',
-            'idempotency-key': idempotencyKey,
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
-        };
-
-        // construct the request
-        const _options = {
-            queryUrl: _queryUrl,
-            method: 'PATCH',
-            headers: _headers,
-            body: _apiHelper.jsonSerialize(request),
-            username: _configuration.basicAuthUserName,
-            password: _configuration.basicAuthPassword,
-        };
-
-        // build the response processing.
-        return new Promise((_fulfill, _reject) => {
-            _request(_options, (_error, _response, _context) => {
-                let errorResponse;
-                if (_error) {
-                    errorResponse = _baseController.validateResponse(_context);
-                    _callback(errorResponse.error, errorResponse.response, errorResponse.context);
-                    _reject(errorResponse.error);
-                } else if (_response.statusCode >= 200 && _response.statusCode <= 206) {
-                    let parsed = JSON.parse(_response.body);
-                    parsed = _baseController.getObjectMapper().mapObject(parsed, 'GetInvoiceResponse');
-                    _callback(null, parsed, _context);
-                    _fulfill(parsed);
-                } else {
-                    errorResponse = _baseController.validateResponse(_context);
-                    _callback(errorResponse.error, errorResponse.response, errorResponse.context);
-                    _reject(errorResponse.error);
-                }
-            });
-        });
-    }
-    /**
      * @todo Add general description for this endpoint
      *
      * @param {string} subscriptionId Subscription Id
@@ -110,7 +42,7 @@ class InvoicesController {
         // prepare headers
         const _headers = {
             accept: 'application/json',
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -175,7 +107,7 @@ class InvoicesController {
         const _headers = {
             accept: 'application/json',
             'idempotency-key': idempotencyKey,
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -244,13 +176,81 @@ class InvoicesController {
             accept: 'application/json',
             'content-type': 'application/json; charset=utf-8',
             'idempotency-key': idempotencyKey,
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
         const _options = {
             queryUrl: _queryUrl,
             method: 'POST',
+            headers: _headers,
+            body: _apiHelper.jsonSerialize(request),
+            username: _configuration.basicAuthUserName,
+            password: _configuration.basicAuthPassword,
+        };
+
+        // build the response processing.
+        return new Promise((_fulfill, _reject) => {
+            _request(_options, (_error, _response, _context) => {
+                let errorResponse;
+                if (_error) {
+                    errorResponse = _baseController.validateResponse(_context);
+                    _callback(errorResponse.error, errorResponse.response, errorResponse.context);
+                    _reject(errorResponse.error);
+                } else if (_response.statusCode >= 200 && _response.statusCode <= 206) {
+                    let parsed = JSON.parse(_response.body);
+                    parsed = _baseController.getObjectMapper().mapObject(parsed, 'GetInvoiceResponse');
+                    _callback(null, parsed, _context);
+                    _fulfill(parsed);
+                } else {
+                    errorResponse = _baseController.validateResponse(_context);
+                    _callback(errorResponse.error, errorResponse.response, errorResponse.context);
+                    _reject(errorResponse.error);
+                }
+            });
+        });
+    }
+    /**
+     * Updates the metadata from an invoice
+     *
+     * @param {string} invoiceId The invoice id
+     * @param {UpdateMetadataRequest} request Request for updating the invoice metadata
+     * @param {string} idempotencyKey (optional) TODO: type description here
+     *
+     * @callback    The callback function that returns response from the API call
+     *
+     * @returns {Promise}
+     */
+    static updateInvoiceMetadata(invoiceId, request, idempotencyKey, callback) {
+        // create empty callback if absent
+        const _callback = typeof callback === 'function' ? callback : () => undefined;
+
+        // prepare query string for API call
+        const _baseUri = _configuration.BASEURI;
+
+        let _pathUrl = '/invoices/{invoice_id}/metadata';
+        // process template parameters
+        _pathUrl = _apiHelper.appendUrlWithTemplateParameters(_pathUrl, {
+            invoice_id: { value: invoiceId, encode: true },
+        });
+
+        const _queryBuilder = `${_baseUri}${_pathUrl}`;
+
+        // validate and preprocess url
+        const _queryUrl = _apiHelper.cleanUrl(_queryBuilder);
+
+        // prepare headers
+        const _headers = {
+            accept: 'application/json',
+            'content-type': 'application/json; charset=utf-8',
+            'idempotency-key': idempotencyKey,
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
+        };
+
+        // construct the request
+        const _options = {
+            queryUrl: _queryUrl,
+            method: 'PATCH',
             headers: _headers,
             body: _apiHelper.jsonSerialize(request),
             username: _configuration.basicAuthUserName,
@@ -339,7 +339,7 @@ class InvoicesController {
         // prepare headers
         const _headers = {
             accept: 'application/json',
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -402,7 +402,7 @@ class InvoicesController {
         // prepare headers
         const _headers = {
             accept: 'application/json',
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -469,7 +469,7 @@ class InvoicesController {
             accept: 'application/json',
             'content-type': 'application/json; charset=utf-8',
             'idempotency-key': idempotencyKey,
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request

--- a/lib/Controllers/OrdersController.js
+++ b/lib/Controllers/OrdersController.js
@@ -54,7 +54,7 @@ class OrdersController {
         // prepare headers
         const _headers = {
             accept: 'application/json',
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -77,6 +77,71 @@ class OrdersController {
                 } else if (_response.statusCode >= 200 && _response.statusCode <= 206) {
                     let parsed = JSON.parse(_response.body);
                     parsed = _baseController.getObjectMapper().mapObject(parsed, 'ListOrderResponse');
+                    _callback(null, parsed, _context);
+                    _fulfill(parsed);
+                } else {
+                    errorResponse = _baseController.validateResponse(_context);
+                    _callback(errorResponse.error, errorResponse.response, errorResponse.context);
+                    _reject(errorResponse.error);
+                }
+            });
+        });
+    }
+    /**
+     * @todo Add general description for this endpoint
+     *
+     * @param {string} orderId Order Id
+     * @param {string} idempotencyKey (optional) TODO: type description here
+     *
+     * @callback    The callback function that returns response from the API call
+     *
+     * @returns {Promise}
+     */
+    static deleteAllOrderItems(orderId, idempotencyKey, callback) {
+        // create empty callback if absent
+        const _callback = typeof callback === 'function' ? callback : () => undefined;
+
+        // prepare query string for API call
+        const _baseUri = _configuration.BASEURI;
+
+        let _pathUrl = '/orders/{orderId}/items';
+        // process template parameters
+        _pathUrl = _apiHelper.appendUrlWithTemplateParameters(_pathUrl, {
+            orderId: { value: orderId, encode: true },
+        });
+
+        const _queryBuilder = `${_baseUri}${_pathUrl}`;
+
+        // validate and preprocess url
+        const _queryUrl = _apiHelper.cleanUrl(_queryBuilder);
+
+        // prepare headers
+        const _headers = {
+            accept: 'application/json',
+            'idempotency-key': idempotencyKey,
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
+        };
+
+        // construct the request
+        const _options = {
+            queryUrl: _queryUrl,
+            method: 'DELETE',
+            headers: _headers,
+            username: _configuration.basicAuthUserName,
+            password: _configuration.basicAuthPassword,
+        };
+
+        // build the response processing.
+        return new Promise((_fulfill, _reject) => {
+            _request(_options, (_error, _response, _context) => {
+                let errorResponse;
+                if (_error) {
+                    errorResponse = _baseController.validateResponse(_context);
+                    _callback(errorResponse.error, errorResponse.response, errorResponse.context);
+                    _reject(errorResponse.error);
+                } else if (_response.statusCode >= 200 && _response.statusCode <= 206) {
+                    let parsed = JSON.parse(_response.body);
+                    parsed = _baseController.getObjectMapper().mapObject(parsed, 'GetOrderResponse');
                     _callback(null, parsed, _context);
                     _fulfill(parsed);
                 } else {
@@ -123,7 +188,7 @@ class OrdersController {
             accept: 'application/json',
             'content-type': 'application/json; charset=utf-8',
             'idempotency-key': idempotencyKey,
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -147,71 +212,6 @@ class OrdersController {
                 } else if (_response.statusCode >= 200 && _response.statusCode <= 206) {
                     let parsed = JSON.parse(_response.body);
                     parsed = _baseController.getObjectMapper().mapObject(parsed, 'GetOrderItemResponse');
-                    _callback(null, parsed, _context);
-                    _fulfill(parsed);
-                } else {
-                    errorResponse = _baseController.validateResponse(_context);
-                    _callback(errorResponse.error, errorResponse.response, errorResponse.context);
-                    _reject(errorResponse.error);
-                }
-            });
-        });
-    }
-    /**
-     * @todo Add general description for this endpoint
-     *
-     * @param {string} orderId Order Id
-     * @param {string} idempotencyKey (optional) TODO: type description here
-     *
-     * @callback    The callback function that returns response from the API call
-     *
-     * @returns {Promise}
-     */
-    static deleteAllOrderItems(orderId, idempotencyKey, callback) {
-        // create empty callback if absent
-        const _callback = typeof callback === 'function' ? callback : () => undefined;
-
-        // prepare query string for API call
-        const _baseUri = _configuration.BASEURI;
-
-        let _pathUrl = '/orders/{orderId}/items';
-        // process template parameters
-        _pathUrl = _apiHelper.appendUrlWithTemplateParameters(_pathUrl, {
-            orderId: { value: orderId, encode: true },
-        });
-
-        const _queryBuilder = `${_baseUri}${_pathUrl}`;
-
-        // validate and preprocess url
-        const _queryUrl = _apiHelper.cleanUrl(_queryBuilder);
-
-        // prepare headers
-        const _headers = {
-            accept: 'application/json',
-            'idempotency-key': idempotencyKey,
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
-        };
-
-        // construct the request
-        const _options = {
-            queryUrl: _queryUrl,
-            method: 'DELETE',
-            headers: _headers,
-            username: _configuration.basicAuthUserName,
-            password: _configuration.basicAuthPassword,
-        };
-
-        // build the response processing.
-        return new Promise((_fulfill, _reject) => {
-            _request(_options, (_error, _response, _context) => {
-                let errorResponse;
-                if (_error) {
-                    errorResponse = _baseController.validateResponse(_context);
-                    _callback(errorResponse.error, errorResponse.response, errorResponse.context);
-                    _reject(errorResponse.error);
-                } else if (_response.statusCode >= 200 && _response.statusCode <= 206) {
-                    let parsed = JSON.parse(_response.body);
-                    parsed = _baseController.getObjectMapper().mapObject(parsed, 'GetOrderResponse');
                     _callback(null, parsed, _context);
                     _fulfill(parsed);
                 } else {
@@ -256,7 +256,7 @@ class OrdersController {
         const _headers = {
             accept: 'application/json',
             'idempotency-key': idempotencyKey,
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -323,7 +323,7 @@ class OrdersController {
             accept: 'application/json',
             'content-type': 'application/json; charset=utf-8',
             'idempotency-key': idempotencyKey,
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -385,7 +385,7 @@ class OrdersController {
             accept: 'application/json',
             'content-type': 'application/json; charset=utf-8',
             'idempotency-key': idempotencyKey,
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -453,7 +453,7 @@ class OrdersController {
             accept: 'application/json',
             'content-type': 'application/json; charset=utf-8',
             'idempotency-key': idempotencyKey,
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -519,7 +519,7 @@ class OrdersController {
         // prepare headers
         const _headers = {
             accept: 'application/json',
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -586,7 +586,7 @@ class OrdersController {
             accept: 'application/json',
             'content-type': 'application/json; charset=utf-8',
             'idempotency-key': idempotencyKey,
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -650,7 +650,7 @@ class OrdersController {
         // prepare headers
         const _headers = {
             accept: 'application/json',
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request

--- a/lib/Controllers/PlansController.js
+++ b/lib/Controllers/PlansController.js
@@ -42,78 +42,13 @@ class PlansController {
         // prepare headers
         const _headers = {
             accept: 'application/json',
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
         const _options = {
             queryUrl: _queryUrl,
             method: 'GET',
-            headers: _headers,
-            username: _configuration.basicAuthUserName,
-            password: _configuration.basicAuthPassword,
-        };
-
-        // build the response processing.
-        return new Promise((_fulfill, _reject) => {
-            _request(_options, (_error, _response, _context) => {
-                let errorResponse;
-                if (_error) {
-                    errorResponse = _baseController.validateResponse(_context);
-                    _callback(errorResponse.error, errorResponse.response, errorResponse.context);
-                    _reject(errorResponse.error);
-                } else if (_response.statusCode >= 200 && _response.statusCode <= 206) {
-                    let parsed = JSON.parse(_response.body);
-                    parsed = _baseController.getObjectMapper().mapObject(parsed, 'GetPlanResponse');
-                    _callback(null, parsed, _context);
-                    _fulfill(parsed);
-                } else {
-                    errorResponse = _baseController.validateResponse(_context);
-                    _callback(errorResponse.error, errorResponse.response, errorResponse.context);
-                    _reject(errorResponse.error);
-                }
-            });
-        });
-    }
-    /**
-     * Deletes a plan
-     *
-     * @param {string} planId Plan id
-     * @param {string} idempotencyKey (optional) TODO: type description here
-     *
-     * @callback    The callback function that returns response from the API call
-     *
-     * @returns {Promise}
-     */
-    static deletePlan(planId, idempotencyKey, callback) {
-        // create empty callback if absent
-        const _callback = typeof callback === 'function' ? callback : () => undefined;
-
-        // prepare query string for API call
-        const _baseUri = _configuration.BASEURI;
-
-        let _pathUrl = '/plans/{plan_id}';
-        // process template parameters
-        _pathUrl = _apiHelper.appendUrlWithTemplateParameters(_pathUrl, {
-            plan_id: { value: planId, encode: true },
-        });
-
-        const _queryBuilder = `${_baseUri}${_pathUrl}`;
-
-        // validate and preprocess url
-        const _queryUrl = _apiHelper.cleanUrl(_queryBuilder);
-
-        // prepare headers
-        const _headers = {
-            accept: 'application/json',
-            'idempotency-key': idempotencyKey,
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
-        };
-
-        // construct the request
-        const _options = {
-            queryUrl: _queryUrl,
-            method: 'DELETE',
             headers: _headers,
             username: _configuration.basicAuthUserName,
             password: _configuration.basicAuthPassword,
@@ -174,7 +109,7 @@ class PlansController {
             accept: 'application/json',
             'content-type': 'application/json; charset=utf-8',
             'idempotency-key': idempotencyKey,
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -244,7 +179,7 @@ class PlansController {
             accept: 'application/json',
             'content-type': 'application/json; charset=utf-8',
             'idempotency-key': idempotencyKey,
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -312,7 +247,7 @@ class PlansController {
             accept: 'application/json',
             'content-type': 'application/json; charset=utf-8',
             'idempotency-key': idempotencyKey,
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -378,7 +313,7 @@ class PlansController {
         // prepare headers
         const _headers = {
             accept: 'application/json',
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -439,7 +374,7 @@ class PlansController {
             accept: 'application/json',
             'content-type': 'application/json; charset=utf-8',
             'idempotency-key': idempotencyKey,
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -507,7 +442,7 @@ class PlansController {
         const _headers = {
             accept: 'application/json',
             'idempotency-key': idempotencyKey,
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -582,7 +517,7 @@ class PlansController {
         // prepare headers
         const _headers = {
             accept: 'application/json',
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -649,7 +584,7 @@ class PlansController {
             accept: 'application/json',
             'content-type': 'application/json; charset=utf-8',
             'idempotency-key': idempotencyKey,
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -658,6 +593,71 @@ class PlansController {
             method: 'PUT',
             headers: _headers,
             body: _apiHelper.jsonSerialize(request),
+            username: _configuration.basicAuthUserName,
+            password: _configuration.basicAuthPassword,
+        };
+
+        // build the response processing.
+        return new Promise((_fulfill, _reject) => {
+            _request(_options, (_error, _response, _context) => {
+                let errorResponse;
+                if (_error) {
+                    errorResponse = _baseController.validateResponse(_context);
+                    _callback(errorResponse.error, errorResponse.response, errorResponse.context);
+                    _reject(errorResponse.error);
+                } else if (_response.statusCode >= 200 && _response.statusCode <= 206) {
+                    let parsed = JSON.parse(_response.body);
+                    parsed = _baseController.getObjectMapper().mapObject(parsed, 'GetPlanResponse');
+                    _callback(null, parsed, _context);
+                    _fulfill(parsed);
+                } else {
+                    errorResponse = _baseController.validateResponse(_context);
+                    _callback(errorResponse.error, errorResponse.response, errorResponse.context);
+                    _reject(errorResponse.error);
+                }
+            });
+        });
+    }
+    /**
+     * Deletes a plan
+     *
+     * @param {string} planId Plan id
+     * @param {string} idempotencyKey (optional) TODO: type description here
+     *
+     * @callback    The callback function that returns response from the API call
+     *
+     * @returns {Promise}
+     */
+    static deletePlan(planId, idempotencyKey, callback) {
+        // create empty callback if absent
+        const _callback = typeof callback === 'function' ? callback : () => undefined;
+
+        // prepare query string for API call
+        const _baseUri = _configuration.BASEURI;
+
+        let _pathUrl = '/plans/{plan_id}';
+        // process template parameters
+        _pathUrl = _apiHelper.appendUrlWithTemplateParameters(_pathUrl, {
+            plan_id: { value: planId, encode: true },
+        });
+
+        const _queryBuilder = `${_baseUri}${_pathUrl}`;
+
+        // validate and preprocess url
+        const _queryUrl = _apiHelper.cleanUrl(_queryBuilder);
+
+        // prepare headers
+        const _headers = {
+            accept: 'application/json',
+            'idempotency-key': idempotencyKey,
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
+        };
+
+        // construct the request
+        const _options = {
+            queryUrl: _queryUrl,
+            method: 'DELETE',
+            headers: _headers,
             username: _configuration.basicAuthUserName,
             password: _configuration.basicAuthPassword,
         };

--- a/lib/Controllers/RecipientsController.js
+++ b/lib/Controllers/RecipientsController.js
@@ -13,6 +13,71 @@ const _baseController = require('./BaseController');
 
 class RecipientsController {
     /**
+     * Gets a transfer
+     *
+     * @param {string} recipientId Recipient id
+     * @param {string} transferId Transfer id
+     *
+     * @callback    The callback function that returns response from the API call
+     *
+     * @returns {Promise}
+     */
+    static getTransfer(recipientId, transferId, callback) {
+        // create empty callback if absent
+        const _callback = typeof callback === 'function' ? callback : () => undefined;
+
+        // prepare query string for API call
+        const _baseUri = _configuration.BASEURI;
+
+        let _pathUrl = '/recipients/{recipient_id}/transfers/{transfer_id}';
+        // process template parameters
+        _pathUrl = _apiHelper.appendUrlWithTemplateParameters(_pathUrl, {
+            recipient_id: { value: recipientId, encode: true },
+            transfer_id: { value: transferId, encode: true },
+        });
+
+        const _queryBuilder = `${_baseUri}${_pathUrl}`;
+
+        // validate and preprocess url
+        const _queryUrl = _apiHelper.cleanUrl(_queryBuilder);
+
+        // prepare headers
+        const _headers = {
+            accept: 'application/json',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
+        };
+
+        // construct the request
+        const _options = {
+            queryUrl: _queryUrl,
+            method: 'GET',
+            headers: _headers,
+            username: _configuration.basicAuthUserName,
+            password: _configuration.basicAuthPassword,
+        };
+
+        // build the response processing.
+        return new Promise((_fulfill, _reject) => {
+            _request(_options, (_error, _response, _context) => {
+                let errorResponse;
+                if (_error) {
+                    errorResponse = _baseController.validateResponse(_context);
+                    _callback(errorResponse.error, errorResponse.response, errorResponse.context);
+                    _reject(errorResponse.error);
+                } else if (_response.statusCode >= 200 && _response.statusCode <= 206) {
+                    let parsed = JSON.parse(_response.body);
+                    parsed = _baseController.getObjectMapper().mapObject(parsed, 'GetTransferResponse');
+                    _callback(null, parsed, _context);
+                    _fulfill(parsed);
+                } else {
+                    errorResponse = _baseController.validateResponse(_context);
+                    _callback(errorResponse.error, errorResponse.response, errorResponse.context);
+                    _reject(errorResponse.error);
+                }
+            });
+        });
+    }
+    /**
      * Updates a recipient
      *
      * @param {string} recipientId Recipient id
@@ -46,7 +111,7 @@ class RecipientsController {
             accept: 'application/json',
             'content-type': 'application/json; charset=utf-8',
             'idempotency-key': idempotencyKey,
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -114,7 +179,7 @@ class RecipientsController {
             accept: 'application/json',
             'content-type': 'application/json; charset=utf-8',
             'idempotency-key': idempotencyKey,
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -186,7 +251,7 @@ class RecipientsController {
         // prepare headers
         const _headers = {
             accept: 'application/json',
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -252,7 +317,7 @@ class RecipientsController {
         // prepare headers
         const _headers = {
             accept: 'application/json',
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -317,7 +382,7 @@ class RecipientsController {
         // prepare headers
         const _headers = {
             accept: 'application/json',
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -384,7 +449,7 @@ class RecipientsController {
             accept: 'application/json',
             'content-type': 'application/json; charset=utf-8',
             'idempotency-key': idempotencyKey,
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -452,7 +517,7 @@ class RecipientsController {
             accept: 'application/json',
             'content-type': 'application/json; charset=utf-8',
             'idempotency-key': idempotencyKey,
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -530,7 +595,7 @@ class RecipientsController {
         // prepare headers
         const _headers = {
             accept: 'application/json',
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -553,71 +618,6 @@ class RecipientsController {
                 } else if (_response.statusCode >= 200 && _response.statusCode <= 206) {
                     let parsed = JSON.parse(_response.body);
                     parsed = _baseController.getObjectMapper().mapObject(parsed, 'ListTransferResponse');
-                    _callback(null, parsed, _context);
-                    _fulfill(parsed);
-                } else {
-                    errorResponse = _baseController.validateResponse(_context);
-                    _callback(errorResponse.error, errorResponse.response, errorResponse.context);
-                    _reject(errorResponse.error);
-                }
-            });
-        });
-    }
-    /**
-     * Gets a transfer
-     *
-     * @param {string} recipientId Recipient id
-     * @param {string} transferId Transfer id
-     *
-     * @callback    The callback function that returns response from the API call
-     *
-     * @returns {Promise}
-     */
-    static getTransfer(recipientId, transferId, callback) {
-        // create empty callback if absent
-        const _callback = typeof callback === 'function' ? callback : () => undefined;
-
-        // prepare query string for API call
-        const _baseUri = _configuration.BASEURI;
-
-        let _pathUrl = '/recipients/{recipient_id}/transfers/{transfer_id}';
-        // process template parameters
-        _pathUrl = _apiHelper.appendUrlWithTemplateParameters(_pathUrl, {
-            recipient_id: { value: recipientId, encode: true },
-            transfer_id: { value: transferId, encode: true },
-        });
-
-        const _queryBuilder = `${_baseUri}${_pathUrl}`;
-
-        // validate and preprocess url
-        const _queryUrl = _apiHelper.cleanUrl(_queryBuilder);
-
-        // prepare headers
-        const _headers = {
-            accept: 'application/json',
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
-        };
-
-        // construct the request
-        const _options = {
-            queryUrl: _queryUrl,
-            method: 'GET',
-            headers: _headers,
-            username: _configuration.basicAuthUserName,
-            password: _configuration.basicAuthPassword,
-        };
-
-        // build the response processing.
-        return new Promise((_fulfill, _reject) => {
-            _request(_options, (_error, _response, _context) => {
-                let errorResponse;
-                if (_error) {
-                    errorResponse = _baseController.validateResponse(_context);
-                    _callback(errorResponse.error, errorResponse.response, errorResponse.context);
-                    _reject(errorResponse.error);
-                } else if (_response.statusCode >= 200 && _response.statusCode <= 206) {
-                    let parsed = JSON.parse(_response.body);
-                    parsed = _baseController.getObjectMapper().mapObject(parsed, 'GetTransferResponse');
                     _callback(null, parsed, _context);
                     _fulfill(parsed);
                 } else {
@@ -660,7 +660,7 @@ class RecipientsController {
         const _headers = {
             accept: 'application/json',
             'content-type': 'application/json; charset=utf-8',
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -728,7 +728,7 @@ class RecipientsController {
             accept: 'application/json',
             'content-type': 'application/json; charset=utf-8',
             'idempotency-key': idempotencyKey,
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -794,7 +794,7 @@ class RecipientsController {
         // prepare headers
         const _headers = {
             accept: 'application/json',
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -861,7 +861,7 @@ class RecipientsController {
             accept: 'application/json',
             'content-type': 'application/json; charset=utf-8',
             'idempotency-key': idempotencyKey,
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -958,7 +958,7 @@ class RecipientsController {
         // prepare headers
         const _headers = {
             accept: 'application/json',
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -1021,7 +1021,7 @@ class RecipientsController {
         // prepare headers
         const _headers = {
             accept: 'application/json',
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -1044,69 +1044,6 @@ class RecipientsController {
                 } else if (_response.statusCode >= 200 && _response.statusCode <= 206) {
                     let parsed = JSON.parse(_response.body);
                     parsed = _baseController.getObjectMapper().mapObject(parsed, 'GetRecipientResponse');
-                    _callback(null, parsed, _context);
-                    _fulfill(parsed);
-                } else {
-                    errorResponse = _baseController.validateResponse(_context);
-                    _callback(errorResponse.error, errorResponse.response, errorResponse.context);
-                    _reject(errorResponse.error);
-                }
-            });
-        });
-    }
-    /**
-     * Get balance information for a recipient
-     *
-     * @param {string} recipientId Recipient id
-     *
-     * @callback    The callback function that returns response from the API call
-     *
-     * @returns {Promise}
-     */
-    static getBalance(recipientId, callback) {
-        // create empty callback if absent
-        const _callback = typeof callback === 'function' ? callback : () => undefined;
-
-        // prepare query string for API call
-        const _baseUri = _configuration.BASEURI;
-
-        let _pathUrl = '/recipients/{recipient_id}/balance';
-        // process template parameters
-        _pathUrl = _apiHelper.appendUrlWithTemplateParameters(_pathUrl, {
-            recipient_id: { value: recipientId, encode: true },
-        });
-
-        const _queryBuilder = `${_baseUri}${_pathUrl}`;
-
-        // validate and preprocess url
-        const _queryUrl = _apiHelper.cleanUrl(_queryBuilder);
-
-        // prepare headers
-        const _headers = {
-            accept: 'application/json',
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
-        };
-
-        // construct the request
-        const _options = {
-            queryUrl: _queryUrl,
-            method: 'GET',
-            headers: _headers,
-            username: _configuration.basicAuthUserName,
-            password: _configuration.basicAuthPassword,
-        };
-
-        // build the response processing.
-        return new Promise((_fulfill, _reject) => {
-            _request(_options, (_error, _response, _context) => {
-                let errorResponse;
-                if (_error) {
-                    errorResponse = _baseController.validateResponse(_context);
-                    _callback(errorResponse.error, errorResponse.response, errorResponse.context);
-                    _reject(errorResponse.error);
-                } else if (_response.statusCode >= 200 && _response.statusCode <= 206) {
-                    let parsed = JSON.parse(_response.body);
-                    parsed = _baseController.getObjectMapper().mapObject(parsed, 'GetBalanceResponse');
                     _callback(null, parsed, _context);
                     _fulfill(parsed);
                 } else {
@@ -1161,7 +1098,7 @@ class RecipientsController {
         // prepare headers
         const _headers = {
             accept: 'application/json',
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -1184,6 +1121,69 @@ class RecipientsController {
                 } else if (_response.statusCode >= 200 && _response.statusCode <= 206) {
                     let parsed = JSON.parse(_response.body);
                     parsed = _baseController.getObjectMapper().mapObject(parsed, 'ListWithdrawals');
+                    _callback(null, parsed, _context);
+                    _fulfill(parsed);
+                } else {
+                    errorResponse = _baseController.validateResponse(_context);
+                    _callback(errorResponse.error, errorResponse.response, errorResponse.context);
+                    _reject(errorResponse.error);
+                }
+            });
+        });
+    }
+    /**
+     * Get balance information for a recipient
+     *
+     * @param {string} recipientId Recipient id
+     *
+     * @callback    The callback function that returns response from the API call
+     *
+     * @returns {Promise}
+     */
+    static getBalance(recipientId, callback) {
+        // create empty callback if absent
+        const _callback = typeof callback === 'function' ? callback : () => undefined;
+
+        // prepare query string for API call
+        const _baseUri = _configuration.BASEURI;
+
+        let _pathUrl = '/recipients/{recipient_id}/balance';
+        // process template parameters
+        _pathUrl = _apiHelper.appendUrlWithTemplateParameters(_pathUrl, {
+            recipient_id: { value: recipientId, encode: true },
+        });
+
+        const _queryBuilder = `${_baseUri}${_pathUrl}`;
+
+        // validate and preprocess url
+        const _queryUrl = _apiHelper.cleanUrl(_queryBuilder);
+
+        // prepare headers
+        const _headers = {
+            accept: 'application/json',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
+        };
+
+        // construct the request
+        const _options = {
+            queryUrl: _queryUrl,
+            method: 'GET',
+            headers: _headers,
+            username: _configuration.basicAuthUserName,
+            password: _configuration.basicAuthPassword,
+        };
+
+        // build the response processing.
+        return new Promise((_fulfill, _reject) => {
+            _request(_options, (_error, _response, _context) => {
+                let errorResponse;
+                if (_error) {
+                    errorResponse = _baseController.validateResponse(_context);
+                    _callback(errorResponse.error, errorResponse.response, errorResponse.context);
+                    _reject(errorResponse.error);
+                } else if (_response.statusCode >= 200 && _response.statusCode <= 206) {
+                    let parsed = JSON.parse(_response.body);
+                    parsed = _baseController.getObjectMapper().mapObject(parsed, 'GetBalanceResponse');
                     _callback(null, parsed, _context);
                     _fulfill(parsed);
                 } else {
@@ -1228,7 +1228,7 @@ class RecipientsController {
             accept: 'application/json',
             'content-type': 'application/json; charset=utf-8',
             'idempotency-key': idempotencyKey,
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -1290,7 +1290,7 @@ class RecipientsController {
             accept: 'application/json',
             'content-type': 'application/json; charset=utf-8',
             'idempotency-key': idempotencyKey,
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -1354,7 +1354,7 @@ class RecipientsController {
         // prepare headers
         const _headers = {
             accept: 'application/json',
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -1410,7 +1410,7 @@ class RecipientsController {
         // prepare headers
         const _headers = {
             accept: 'application/json',
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request

--- a/lib/Controllers/SubscriptionsController.js
+++ b/lib/Controllers/SubscriptionsController.js
@@ -13,71 +13,6 @@ const _baseController = require('./BaseController');
 
 class SubscriptionsController {
     /**
-     * @todo Add general description for this endpoint
-     *
-     * @param {string} subscriptionId TODO: type description here
-     * @param {string} idempotencyKey (optional) TODO: type description here
-     *
-     * @callback    The callback function that returns response from the API call
-     *
-     * @returns {Promise}
-     */
-    static renewSubscription(subscriptionId, idempotencyKey, callback) {
-        // create empty callback if absent
-        const _callback = typeof callback === 'function' ? callback : () => undefined;
-
-        // prepare query string for API call
-        const _baseUri = _configuration.BASEURI;
-
-        let _pathUrl = '/subscriptions/{subscription_id}/cycles';
-        // process template parameters
-        _pathUrl = _apiHelper.appendUrlWithTemplateParameters(_pathUrl, {
-            subscription_id: { value: subscriptionId, encode: true },
-        });
-
-        const _queryBuilder = `${_baseUri}${_pathUrl}`;
-
-        // validate and preprocess url
-        const _queryUrl = _apiHelper.cleanUrl(_queryBuilder);
-
-        // prepare headers
-        const _headers = {
-            accept: 'application/json',
-            'idempotency-key': idempotencyKey,
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
-        };
-
-        // construct the request
-        const _options = {
-            queryUrl: _queryUrl,
-            method: 'POST',
-            headers: _headers,
-            username: _configuration.basicAuthUserName,
-            password: _configuration.basicAuthPassword,
-        };
-
-        // build the response processing.
-        return new Promise((_fulfill, _reject) => {
-            _request(_options, (_error, _response, _context) => {
-                let errorResponse;
-                if (_error) {
-                    errorResponse = _baseController.validateResponse(_context);
-                    _callback(errorResponse.error, errorResponse.response, errorResponse.context);
-                    _reject(errorResponse.error);
-                } else if (_response.statusCode >= 200 && _response.statusCode <= 206) {
-                    let parsed = JSON.parse(_response.body);
-                    parsed = _baseController.getObjectMapper().mapObject(parsed, 'GetPeriodResponse');
-                    _callback(null, parsed, _context);
-                    _fulfill(parsed);
-                } else {
-                    errorResponse = _baseController.validateResponse(_context);
-                    _callback(errorResponse.error, errorResponse.response, errorResponse.context);
-                    _reject(errorResponse.error);
-                }
-            });
-        });
-    }
-    /**
      * Updates the credit card from a subscription
      *
      * @param {string} subscriptionId Subscription id
@@ -111,7 +46,7 @@ class SubscriptionsController {
             accept: 'application/json',
             'content-type': 'application/json; charset=utf-8',
             'idempotency-key': idempotencyKey,
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -181,7 +116,7 @@ class SubscriptionsController {
         const _headers = {
             accept: 'application/json',
             'idempotency-key': idempotencyKey,
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -248,7 +183,7 @@ class SubscriptionsController {
             accept: 'application/json',
             'content-type': 'application/json; charset=utf-8',
             'idempotency-key': idempotencyKey,
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -316,7 +251,7 @@ class SubscriptionsController {
         const _headers = {
             accept: 'application/json',
             'idempotency-key': idempotencyKey,
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -383,7 +318,7 @@ class SubscriptionsController {
         const _headers = {
             'content-type': 'application/json; charset=utf-8',
             'idempotency-key': idempotencyKey,
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -407,6 +342,75 @@ class SubscriptionsController {
                 } else if (_response.statusCode >= 200 && _response.statusCode <= 206) {
                     _callback(null, null, _context);
                     _fulfill();
+                } else {
+                    errorResponse = _baseController.validateResponse(_context);
+                    _callback(errorResponse.error, errorResponse.response, errorResponse.context);
+                    _reject(errorResponse.error);
+                }
+            });
+        });
+    }
+    /**
+     * Updates the payment method from a subscription
+     *
+     * @param {string} subscriptionId Subscription id
+     * @param {UpdateSubscriptionPaymentMethodRequest} request Request for updating the
+     * paymentmethod from a subscription
+     * @param {string} idempotencyKey (optional) TODO: type description here
+     *
+     * @callback    The callback function that returns response from the API call
+     *
+     * @returns {Promise}
+     */
+    static updateSubscriptionPaymentMethod(subscriptionId, request, idempotencyKey, callback) {
+        // create empty callback if absent
+        const _callback = typeof callback === 'function' ? callback : () => undefined;
+
+        // prepare query string for API call
+        const _baseUri = _configuration.BASEURI;
+
+        let _pathUrl = '/subscriptions/{subscription_id}/payment-method';
+        // process template parameters
+        _pathUrl = _apiHelper.appendUrlWithTemplateParameters(_pathUrl, {
+            subscription_id: { value: subscriptionId, encode: true },
+        });
+
+        const _queryBuilder = `${_baseUri}${_pathUrl}`;
+
+        // validate and preprocess url
+        const _queryUrl = _apiHelper.cleanUrl(_queryBuilder);
+
+        // prepare headers
+        const _headers = {
+            accept: 'application/json',
+            'content-type': 'application/json; charset=utf-8',
+            'idempotency-key': idempotencyKey,
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
+        };
+
+        // construct the request
+        const _options = {
+            queryUrl: _queryUrl,
+            method: 'PATCH',
+            headers: _headers,
+            body: _apiHelper.jsonSerialize(request),
+            username: _configuration.basicAuthUserName,
+            password: _configuration.basicAuthPassword,
+        };
+
+        // build the response processing.
+        return new Promise((_fulfill, _reject) => {
+            _request(_options, (_error, _response, _context) => {
+                let errorResponse;
+                if (_error) {
+                    errorResponse = _baseController.validateResponse(_context);
+                    _callback(errorResponse.error, errorResponse.response, errorResponse.context);
+                    _reject(errorResponse.error);
+                } else if (_response.statusCode >= 200 && _response.statusCode <= 206) {
+                    let parsed = JSON.parse(_response.body);
+                    parsed = _baseController.getObjectMapper().mapObject(parsed, 'GetSubscriptionResponse');
+                    _callback(null, parsed, _context);
+                    _fulfill(parsed);
                 } else {
                     errorResponse = _baseController.validateResponse(_context);
                     _callback(errorResponse.error, errorResponse.response, errorResponse.context);
@@ -449,7 +453,7 @@ class SubscriptionsController {
         const _headers = {
             accept: 'application/json',
             'idempotency-key': idempotencyKey,
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -541,7 +545,7 @@ class SubscriptionsController {
         // prepare headers
         const _headers = {
             accept: 'application/json',
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -565,75 +569,6 @@ class SubscriptionsController {
                     let parsed = JSON.parse(_response.body);
                     parsed = _baseController.getObjectMapper()
                 .mapObject(parsed, 'ListSubscriptionItemsResponse');
-                    _callback(null, parsed, _context);
-                    _fulfill(parsed);
-                } else {
-                    errorResponse = _baseController.validateResponse(_context);
-                    _callback(errorResponse.error, errorResponse.response, errorResponse.context);
-                    _reject(errorResponse.error);
-                }
-            });
-        });
-    }
-    /**
-     * Updates the payment method from a subscription
-     *
-     * @param {string} subscriptionId Subscription id
-     * @param {UpdateSubscriptionPaymentMethodRequest} request Request for updating the
-     * paymentmethod from a subscription
-     * @param {string} idempotencyKey (optional) TODO: type description here
-     *
-     * @callback    The callback function that returns response from the API call
-     *
-     * @returns {Promise}
-     */
-    static updateSubscriptionPaymentMethod(subscriptionId, request, idempotencyKey, callback) {
-        // create empty callback if absent
-        const _callback = typeof callback === 'function' ? callback : () => undefined;
-
-        // prepare query string for API call
-        const _baseUri = _configuration.BASEURI;
-
-        let _pathUrl = '/subscriptions/{subscription_id}/payment-method';
-        // process template parameters
-        _pathUrl = _apiHelper.appendUrlWithTemplateParameters(_pathUrl, {
-            subscription_id: { value: subscriptionId, encode: true },
-        });
-
-        const _queryBuilder = `${_baseUri}${_pathUrl}`;
-
-        // validate and preprocess url
-        const _queryUrl = _apiHelper.cleanUrl(_queryBuilder);
-
-        // prepare headers
-        const _headers = {
-            accept: 'application/json',
-            'content-type': 'application/json; charset=utf-8',
-            'idempotency-key': idempotencyKey,
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
-        };
-
-        // construct the request
-        const _options = {
-            queryUrl: _queryUrl,
-            method: 'PATCH',
-            headers: _headers,
-            body: _apiHelper.jsonSerialize(request),
-            username: _configuration.basicAuthUserName,
-            password: _configuration.basicAuthPassword,
-        };
-
-        // build the response processing.
-        return new Promise((_fulfill, _reject) => {
-            _request(_options, (_error, _response, _context) => {
-                let errorResponse;
-                if (_error) {
-                    errorResponse = _baseController.validateResponse(_context);
-                    _callback(errorResponse.error, errorResponse.response, errorResponse.context);
-                    _reject(errorResponse.error);
-                } else if (_response.statusCode >= 200 && _response.statusCode <= 206) {
-                    let parsed = JSON.parse(_response.body);
-                    parsed = _baseController.getObjectMapper().mapObject(parsed, 'GetSubscriptionResponse');
                     _callback(null, parsed, _context);
                     _fulfill(parsed);
                 } else {
@@ -676,7 +611,7 @@ class SubscriptionsController {
         // prepare headers
         const _headers = {
             accept: 'application/json',
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -776,7 +711,7 @@ class SubscriptionsController {
         // prepare headers
         const _headers = {
             accept: 'application/json',
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -844,7 +779,7 @@ class SubscriptionsController {
             accept: 'application/json',
             'content-type': 'application/json; charset=utf-8',
             'idempotency-key': idempotencyKey,
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -912,7 +847,7 @@ class SubscriptionsController {
             accept: 'application/json',
             'content-type': 'application/json; charset=utf-8',
             'idempotency-key': idempotencyKey,
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -982,7 +917,7 @@ class SubscriptionsController {
             accept: 'application/json',
             'content-type': 'application/json; charset=utf-8',
             'idempotency-key': idempotencyKey,
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -1006,6 +941,68 @@ class SubscriptionsController {
                 } else if (_response.statusCode >= 200 && _response.statusCode <= 206) {
                     let parsed = JSON.parse(_response.body);
                     parsed = _baseController.getObjectMapper().mapObject(parsed, 'GetUsageResponse');
+                    _callback(null, parsed, _context);
+                    _fulfill(parsed);
+                } else {
+                    errorResponse = _baseController.validateResponse(_context);
+                    _callback(errorResponse.error, errorResponse.response, errorResponse.context);
+                    _reject(errorResponse.error);
+                }
+            });
+        });
+    }
+    /**
+     * Creates a new subscription
+     *
+     * @param {CreateSubscriptionRequest} body Request for creating a subscription
+     * @param {string} idempotencyKey (optional) TODO: type description here
+     *
+     * @callback    The callback function that returns response from the API call
+     *
+     * @returns {Promise}
+     */
+    static createSubscription(body, idempotencyKey, callback) {
+        // create empty callback if absent
+        const _callback = typeof callback === 'function' ? callback : () => undefined;
+
+        // prepare query string for API call
+        const _baseUri = _configuration.BASEURI;
+
+        const _pathUrl = '/subscriptions';
+        const _queryBuilder = `${_baseUri}${_pathUrl}`;
+
+        // validate and preprocess url
+        const _queryUrl = _apiHelper.cleanUrl(_queryBuilder);
+
+        // prepare headers
+        const _headers = {
+            accept: 'application/json',
+            'content-type': 'application/json; charset=utf-8',
+            'idempotency-key': idempotencyKey,
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
+        };
+
+        // construct the request
+        const _options = {
+            queryUrl: _queryUrl,
+            method: 'POST',
+            headers: _headers,
+            body: _apiHelper.jsonSerialize(body),
+            username: _configuration.basicAuthUserName,
+            password: _configuration.basicAuthPassword,
+        };
+
+        // build the response processing.
+        return new Promise((_fulfill, _reject) => {
+            _request(_options, (_error, _response, _context) => {
+                let errorResponse;
+                if (_error) {
+                    errorResponse = _baseController.validateResponse(_context);
+                    _callback(errorResponse.error, errorResponse.response, errorResponse.context);
+                    _reject(errorResponse.error);
+                } else if (_response.statusCode >= 200 && _response.statusCode <= 206) {
+                    let parsed = JSON.parse(_response.body);
+                    parsed = _baseController.getObjectMapper().mapObject(parsed, 'GetSubscriptionResponse');
                     _callback(null, parsed, _context);
                     _fulfill(parsed);
                 } else {
@@ -1048,7 +1045,7 @@ class SubscriptionsController {
         // prepare headers
         const _headers = {
             accept: 'application/json',
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -1071,133 +1068,6 @@ class SubscriptionsController {
                 } else if (_response.statusCode >= 200 && _response.statusCode <= 206) {
                     let parsed = JSON.parse(_response.body);
                     parsed = _baseController.getObjectMapper().mapObject(parsed, 'GetDiscountResponse');
-                    _callback(null, parsed, _context);
-                    _fulfill(parsed);
-                } else {
-                    errorResponse = _baseController.validateResponse(_context);
-                    _callback(errorResponse.error, errorResponse.response, errorResponse.context);
-                    _reject(errorResponse.error);
-                }
-            });
-        });
-    }
-    /**
-     * Creates a new subscription
-     *
-     * @param {CreateSubscriptionRequest} body Request for creating a subscription
-     * @param {string} idempotencyKey (optional) TODO: type description here
-     *
-     * @callback    The callback function that returns response from the API call
-     *
-     * @returns {Promise}
-     */
-    static createSubscription(body, idempotencyKey, callback) {
-        // create empty callback if absent
-        const _callback = typeof callback === 'function' ? callback : () => undefined;
-
-        // prepare query string for API call
-        const _baseUri = _configuration.BASEURI;
-
-        const _pathUrl = '/subscriptions';
-        const _queryBuilder = `${_baseUri}${_pathUrl}`;
-
-        // validate and preprocess url
-        const _queryUrl = _apiHelper.cleanUrl(_queryBuilder);
-
-        // prepare headers
-        const _headers = {
-            accept: 'application/json',
-            'content-type': 'application/json; charset=utf-8',
-            'idempotency-key': idempotencyKey,
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
-        };
-
-        // construct the request
-        const _options = {
-            queryUrl: _queryUrl,
-            method: 'POST',
-            headers: _headers,
-            body: _apiHelper.jsonSerialize(body),
-            username: _configuration.basicAuthUserName,
-            password: _configuration.basicAuthPassword,
-        };
-
-        // build the response processing.
-        return new Promise((_fulfill, _reject) => {
-            _request(_options, (_error, _response, _context) => {
-                let errorResponse;
-                if (_error) {
-                    errorResponse = _baseController.validateResponse(_context);
-                    _callback(errorResponse.error, errorResponse.response, errorResponse.context);
-                    _reject(errorResponse.error);
-                } else if (_response.statusCode >= 200 && _response.statusCode <= 206) {
-                    let parsed = JSON.parse(_response.body);
-                    parsed = _baseController.getObjectMapper().mapObject(parsed, 'GetSubscriptionResponse');
-                    _callback(null, parsed, _context);
-                    _fulfill(parsed);
-                } else {
-                    errorResponse = _baseController.validateResponse(_context);
-                    _callback(errorResponse.error, errorResponse.response, errorResponse.context);
-                    _reject(errorResponse.error);
-                }
-            });
-        });
-    }
-    /**
-     * @todo Add general description for this endpoint
-     *
-     * @param {string} subscriptionId The subscription Id
-     * @param {string} incrementId The increment Id
-     *
-     * @callback    The callback function that returns response from the API call
-     *
-     * @returns {Promise}
-     */
-    static getIncrementById(subscriptionId, incrementId, callback) {
-        // create empty callback if absent
-        const _callback = typeof callback === 'function' ? callback : () => undefined;
-
-        // prepare query string for API call
-        const _baseUri = _configuration.BASEURI;
-
-        let _pathUrl = '/subscriptions/{subscription_id}/increments/{increment_id}';
-        // process template parameters
-        _pathUrl = _apiHelper.appendUrlWithTemplateParameters(_pathUrl, {
-            subscription_id: { value: subscriptionId, encode: true },
-            increment_id: { value: incrementId, encode: true },
-        });
-
-        const _queryBuilder = `${_baseUri}${_pathUrl}`;
-
-        // validate and preprocess url
-        const _queryUrl = _apiHelper.cleanUrl(_queryBuilder);
-
-        // prepare headers
-        const _headers = {
-            accept: 'application/json',
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
-        };
-
-        // construct the request
-        const _options = {
-            queryUrl: _queryUrl,
-            method: 'GET',
-            headers: _headers,
-            username: _configuration.basicAuthUserName,
-            password: _configuration.basicAuthPassword,
-        };
-
-        // build the response processing.
-        return new Promise((_fulfill, _reject) => {
-            _request(_options, (_error, _response, _context) => {
-                let errorResponse;
-                if (_error) {
-                    errorResponse = _baseController.validateResponse(_context);
-                    _callback(errorResponse.error, errorResponse.response, errorResponse.context);
-                    _reject(errorResponse.error);
-                } else if (_response.statusCode >= 200 && _response.statusCode <= 206) {
-                    let parsed = JSON.parse(_response.body);
-                    parsed = _baseController.getObjectMapper().mapObject(parsed, 'GetIncrementResponse');
                     _callback(null, parsed, _context);
                     _fulfill(parsed);
                 } else {
@@ -1243,7 +1113,7 @@ class SubscriptionsController {
             accept: 'application/json',
             'content-type': 'application/json; charset=utf-8',
             'idempotency-key': idempotencyKey,
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -1311,7 +1181,7 @@ class SubscriptionsController {
             accept: 'application/json',
             'content-type': 'application/json; charset=utf-8',
             'idempotency-key': idempotencyKey,
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -1379,7 +1249,7 @@ class SubscriptionsController {
         const _headers = {
             accept: 'application/json',
             'idempotency-key': idempotencyKey,
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -1450,7 +1320,7 @@ class SubscriptionsController {
         // prepare headers
         const _headers = {
             accept: 'application/json',
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -1473,6 +1343,71 @@ class SubscriptionsController {
                 } else if (_response.statusCode >= 200 && _response.statusCode <= 206) {
                     let parsed = JSON.parse(_response.body);
                     parsed = _baseController.getObjectMapper().mapObject(parsed, 'ListCyclesResponse');
+                    _callback(null, parsed, _context);
+                    _fulfill(parsed);
+                } else {
+                    errorResponse = _baseController.validateResponse(_context);
+                    _callback(errorResponse.error, errorResponse.response, errorResponse.context);
+                    _reject(errorResponse.error);
+                }
+            });
+        });
+    }
+    /**
+     * @todo Add general description for this endpoint
+     *
+     * @param {string} subscriptionId The subscription Id
+     * @param {string} incrementId The increment Id
+     *
+     * @callback    The callback function that returns response from the API call
+     *
+     * @returns {Promise}
+     */
+    static getIncrementById(subscriptionId, incrementId, callback) {
+        // create empty callback if absent
+        const _callback = typeof callback === 'function' ? callback : () => undefined;
+
+        // prepare query string for API call
+        const _baseUri = _configuration.BASEURI;
+
+        let _pathUrl = '/subscriptions/{subscription_id}/increments/{increment_id}';
+        // process template parameters
+        _pathUrl = _apiHelper.appendUrlWithTemplateParameters(_pathUrl, {
+            subscription_id: { value: subscriptionId, encode: true },
+            increment_id: { value: incrementId, encode: true },
+        });
+
+        const _queryBuilder = `${_baseUri}${_pathUrl}`;
+
+        // validate and preprocess url
+        const _queryUrl = _apiHelper.cleanUrl(_queryBuilder);
+
+        // prepare headers
+        const _headers = {
+            accept: 'application/json',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
+        };
+
+        // construct the request
+        const _options = {
+            queryUrl: _queryUrl,
+            method: 'GET',
+            headers: _headers,
+            username: _configuration.basicAuthUserName,
+            password: _configuration.basicAuthPassword,
+        };
+
+        // build the response processing.
+        return new Promise((_fulfill, _reject) => {
+            _request(_options, (_error, _response, _context) => {
+                let errorResponse;
+                if (_error) {
+                    errorResponse = _baseController.validateResponse(_context);
+                    _callback(errorResponse.error, errorResponse.response, errorResponse.context);
+                    _reject(errorResponse.error);
+                } else if (_response.statusCode >= 200 && _response.statusCode <= 206) {
+                    let parsed = JSON.parse(_response.body);
+                    parsed = _baseController.getObjectMapper().mapObject(parsed, 'GetIncrementResponse');
                     _callback(null, parsed, _context);
                     _fulfill(parsed);
                 } else {
@@ -1521,7 +1456,7 @@ class SubscriptionsController {
         // prepare headers
         const _headers = {
             accept: 'application/json',
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -1589,7 +1524,7 @@ class SubscriptionsController {
             accept: 'application/json',
             'content-type': 'application/json; charset=utf-8',
             'idempotency-key': idempotencyKey,
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -1657,7 +1592,7 @@ class SubscriptionsController {
         const _headers = {
             accept: 'application/json',
             'idempotency-key': idempotencyKey,
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -1728,7 +1663,7 @@ class SubscriptionsController {
         // prepare headers
         const _headers = {
             accept: 'application/json',
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -1795,7 +1730,7 @@ class SubscriptionsController {
             accept: 'application/json',
             'content-type': 'application/json; charset=utf-8',
             'idempotency-key': idempotencyKey,
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -1864,7 +1799,7 @@ class SubscriptionsController {
             accept: 'application/json',
             'content-type': 'application/json; charset=utf-8',
             'idempotency-key': idempotencyKey,
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -1934,7 +1869,7 @@ class SubscriptionsController {
             accept: 'application/json',
             'content-type': 'application/json; charset=utf-8',
             'idempotency-key': idempotencyKey,
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -2002,7 +1937,7 @@ class SubscriptionsController {
             accept: 'application/json',
             'content-type': 'application/json; charset=utf-8',
             'idempotency-key': idempotencyKey,
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -2066,7 +2001,7 @@ class SubscriptionsController {
         // prepare headers
         const _headers = {
             accept: 'application/json',
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -2155,7 +2090,7 @@ class SubscriptionsController {
         // prepare headers
         const _headers = {
             accept: 'application/json',
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -2223,7 +2158,7 @@ class SubscriptionsController {
             accept: 'application/json',
             'content-type': 'application/json; charset=utf-8',
             'idempotency-key': idempotencyKey,
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -2292,7 +2227,7 @@ class SubscriptionsController {
             accept: 'application/json',
             'content-type': 'application/json; charset=utf-8',
             'idempotency-key': idempotencyKey,
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -2358,13 +2293,78 @@ class SubscriptionsController {
         // prepare headers
         const _headers = {
             accept: 'application/json',
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
         const _options = {
             queryUrl: _queryUrl,
             method: 'GET',
+            headers: _headers,
+            username: _configuration.basicAuthUserName,
+            password: _configuration.basicAuthPassword,
+        };
+
+        // build the response processing.
+        return new Promise((_fulfill, _reject) => {
+            _request(_options, (_error, _response, _context) => {
+                let errorResponse;
+                if (_error) {
+                    errorResponse = _baseController.validateResponse(_context);
+                    _callback(errorResponse.error, errorResponse.response, errorResponse.context);
+                    _reject(errorResponse.error);
+                } else if (_response.statusCode >= 200 && _response.statusCode <= 206) {
+                    let parsed = JSON.parse(_response.body);
+                    parsed = _baseController.getObjectMapper().mapObject(parsed, 'GetPeriodResponse');
+                    _callback(null, parsed, _context);
+                    _fulfill(parsed);
+                } else {
+                    errorResponse = _baseController.validateResponse(_context);
+                    _callback(errorResponse.error, errorResponse.response, errorResponse.context);
+                    _reject(errorResponse.error);
+                }
+            });
+        });
+    }
+    /**
+     * @todo Add general description for this endpoint
+     *
+     * @param {string} subscriptionId TODO: type description here
+     * @param {string} idempotencyKey (optional) TODO: type description here
+     *
+     * @callback    The callback function that returns response from the API call
+     *
+     * @returns {Promise}
+     */
+    static renewSubscription(subscriptionId, idempotencyKey, callback) {
+        // create empty callback if absent
+        const _callback = typeof callback === 'function' ? callback : () => undefined;
+
+        // prepare query string for API call
+        const _baseUri = _configuration.BASEURI;
+
+        let _pathUrl = '/subscriptions/{subscription_id}/cycles';
+        // process template parameters
+        _pathUrl = _apiHelper.appendUrlWithTemplateParameters(_pathUrl, {
+            subscription_id: { value: subscriptionId, encode: true },
+        });
+
+        const _queryBuilder = `${_baseUri}${_pathUrl}`;
+
+        // validate and preprocess url
+        const _queryUrl = _apiHelper.cleanUrl(_queryBuilder);
+
+        // prepare headers
+        const _headers = {
+            accept: 'application/json',
+            'idempotency-key': idempotencyKey,
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
+        };
+
+        // construct the request
+        const _options = {
+            queryUrl: _queryUrl,
+            method: 'POST',
             headers: _headers,
             username: _configuration.basicAuthUserName,
             password: _configuration.basicAuthPassword,
@@ -2423,7 +2423,7 @@ class SubscriptionsController {
         // prepare headers
         const _headers = {
             accept: 'application/json',
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request

--- a/lib/Controllers/TokensController.js
+++ b/lib/Controllers/TokensController.js
@@ -46,7 +46,7 @@ class TokensController {
             accept: 'application/json',
             'content-type': 'application/json; charset=utf-8',
             'idempotency-key': idempotencyKey,
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -110,7 +110,7 @@ class TokensController {
         // prepare headers
         const _headers = {
             accept: 'application/json',
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request

--- a/lib/Controllers/TransactionsController.js
+++ b/lib/Controllers/TransactionsController.js
@@ -42,7 +42,7 @@ class TransactionsController {
         // prepare headers
         const _headers = {
             accept: 'application/json',
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request

--- a/lib/Controllers/TransfersController.js
+++ b/lib/Controllers/TransfersController.js
@@ -42,7 +42,7 @@ class TransfersController {
         // prepare headers
         const _headers = {
             accept: 'application/json',
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -101,7 +101,7 @@ class TransfersController {
         const _headers = {
             accept: 'application/json',
             'content-type': 'application/json; charset=utf-8',
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request
@@ -158,7 +158,7 @@ class TransfersController {
         // prepare headers
         const _headers = {
             accept: 'application/json',
-            'user-agent': 'PagarmeCoreApi - Node 5.2.0',
+            'user-agent': 'PagarmeCoreApi - Node 5.3.0',
         };
 
         // construct the request

--- a/lib/ModelFactory.js
+++ b/lib/ModelFactory.js
@@ -8,17 +8,18 @@
 
 const ListInvoicesResponse = require('../lib/Models/ListInvoicesResponse');
 const GetCheckoutBoletoPaymentResponse = require('../lib/Models/GetCheckoutBoletoPaymentResponse');
-const CreateCardOptionsRequest = require('../lib/Models/CreateCardOptionsRequest');
+const UpdatePriceBracketRequest = require('../lib/Models/UpdatePriceBracketRequest');
 const UpdateSubscriptionBillingDateRequest =
   require('../lib/Models/UpdateSubscriptionBillingDateRequest');
 const ListChargesResponse = require('../lib/Models/ListChargesResponse');
 const ListSubscriptionsResponse = require('../lib/Models/ListSubscriptionsResponse');
 const PagingResponse = require('../lib/Models/PagingResponse');
+const CreateCardOptionsRequest = require('../lib/Models/CreateCardOptionsRequest');
 const ListTransactionsResponse = require('../lib/Models/ListTransactionsResponse');
 const GetPlanItemResponse = require('../lib/Models/GetPlanItemResponse');
+const ListCardsResponse = require('../lib/Models/ListCardsResponse');
 const GetPhonesResponse = require('../lib/Models/GetPhonesResponse');
 const CreateCardTokenRequest = require('../lib/Models/CreateCardTokenRequest');
-const ListCardsResponse = require('../lib/Models/ListCardsResponse');
 const GetPricingSchemeResponse = require('../lib/Models/GetPricingSchemeResponse');
 const GetPriceBracketResponse = require('../lib/Models/GetPriceBracketResponse');
 const GetTokenResponse = require('../lib/Models/GetTokenResponse');
@@ -56,47 +57,43 @@ const CreatePriceBracketRequest = require('../lib/Models/CreatePriceBracketReque
 const GetCardTokenResponse = require('../lib/Models/GetCardTokenResponse');
 const GetCheckoutCardInstallmentOptionsResponse =
   require('../lib/Models/GetCheckoutCardInstallmentOptionsResponse');
-const CreatePricingSchemeRequest = require('../lib/Models/CreatePricingSchemeRequest');
 const CreateCancelSubscriptionRequest = require('../lib/Models/CreateCancelSubscriptionRequest');
 const UpdateCardRequest = require('../lib/Models/UpdateCardRequest');
 const CreatePlanRequest = require('../lib/Models/CreatePlanRequest');
 const CreateBankTransferPaymentRequest = require('../lib/Models/CreateBankTransferPaymentRequest');
+const CreatePricingSchemeRequest = require('../lib/Models/CreatePricingSchemeRequest');
 const CreatePhonesRequest = require('../lib/Models/CreatePhonesRequest');
 const CreateVoucherPaymentRequest = require('../lib/Models/CreateVoucherPaymentRequest');
 const CreateCheckoutBoletoPaymentRequest =
   require('../lib/Models/CreateCheckoutBoletoPaymentRequest');
 const UpdateChargeDueDateRequest = require('../lib/Models/UpdateChargeDueDateRequest');
-const ListSubscriptionItemsResponse = require('../lib/Models/ListSubscriptionItemsResponse');
 const CreateAccessTokenRequest = require('../lib/Models/CreateAccessTokenRequest');
 const GetPhoneResponse = require('../lib/Models/GetPhoneResponse');
 const GetVoucherTransactionResponse = require('../lib/Models/GetVoucherTransactionResponse');
+const ListSubscriptionItemsResponse = require('../lib/Models/ListSubscriptionItemsResponse');
 const ListOrderResponse = require('../lib/Models/ListOrderResponse');
 const ListAddressesResponse = require('../lib/Models/ListAddressesResponse');
 const GetDiscountResponse = require('../lib/Models/GetDiscountResponse');
 const GetCustomerResponse = require('../lib/Models/GetCustomerResponse');
 const CreateAddressRequest = require('../lib/Models/CreateAddressRequest');
-const UpdatePriceBracketRequest = require('../lib/Models/UpdatePriceBracketRequest');
-const GetSellerResponse = require('../lib/Models/GetSellerResponse');
 const CreateSubscriptionItemRequest = require('../lib/Models/CreateSubscriptionItemRequest');
-const GetSellersRequest = require('../lib/Models/GetSellersRequest');
 const CreateOrderRequest = require('../lib/Models/CreateOrderRequest');
 const GetGatewayResponseResponse = require('../lib/Models/GetGatewayResponseResponse');
 const CreateDeviceRequest = require('../lib/Models/CreateDeviceRequest');
 const UpdateSubscriptionAffiliationIdRequest =
   require('../lib/Models/UpdateSubscriptionAffiliationIdRequest');
-const ListSellerResponse = require('../lib/Models/ListSellerResponse');
 const GetIncrementResponse = require('../lib/Models/GetIncrementResponse');
 const CreateThreeDSecureRequest = require('../lib/Models/CreateThreeDSecureRequest');
 const UpdateChargePaymentMethodRequest = require('../lib/Models/UpdateChargePaymentMethodRequest');
 const GetRecipientResponse = require('../lib/Models/GetRecipientResponse');
 const UpdateRecipientRequest = require('../lib/Models/UpdateRecipientRequest');
+const GetGatewayRecipientResponse = require('../lib/Models/GetGatewayRecipientResponse');
+const ListIncrementsResponse = require('../lib/Models/ListIncrementsResponse');
 const CreateAnticipationRequest = require('../lib/Models/CreateAnticipationRequest');
 const GetAnticipationLimitsResponse = require('../lib/Models/GetAnticipationLimitsResponse');
 const GetInvoiceItemResponse = require('../lib/Models/GetInvoiceItemResponse');
 const CreateDiscountRequest = require('../lib/Models/CreateDiscountRequest');
 const GetCardResponse = require('../lib/Models/GetCardResponse');
-const GetGatewayRecipientResponse = require('../lib/Models/GetGatewayRecipientResponse');
-const ListIncrementsResponse = require('../lib/Models/ListIncrementsResponse');
 const CreateBankAccountRequest = require('../lib/Models/CreateBankAccountRequest');
 const GetBalanceResponse = require('../lib/Models/GetBalanceResponse');
 const UpdateOrderItemRequest = require('../lib/Models/UpdateOrderItemRequest');
@@ -104,61 +101,67 @@ const CreateBoletoPaymentRequest = require('../lib/Models/CreateBoletoPaymentReq
 const ListAnticipationResponse = require('../lib/Models/ListAnticipationResponse');
 const UpdateAddressRequest = require('../lib/Models/UpdateAddressRequest');
 const GetBoletoTransactionResponse = require('../lib/Models/GetBoletoTransactionResponse');
+const GetLocationResponse = require('../lib/Models/GetLocationResponse');
 const GetSubscriptionItemResponse = require('../lib/Models/GetSubscriptionItemResponse');
 const GetDebitCardTransactionResponse = require('../lib/Models/GetDebitCardTransactionResponse');
-const GetLocationResponse = require('../lib/Models/GetLocationResponse');
 const CreateTransferSettingsRequest = require('../lib/Models/CreateTransferSettingsRequest');
-const GetGatewayErrorResponse = require('../lib/Models/GetGatewayErrorResponse');
 const CreateTransferRequest = require('../lib/Models/CreateTransferRequest');
-const GetBillingAddressResponse = require('../lib/Models/GetBillingAddressResponse');
+const GetGatewayErrorResponse = require('../lib/Models/GetGatewayErrorResponse');
 const ListTransferResponse = require('../lib/Models/ListTransferResponse');
 const CreateUsageRequest = require('../lib/Models/CreateUsageRequest');
 const CreatePaymentAuthenticationRequest =
   require('../lib/Models/CreatePaymentAuthenticationRequest');
-const CreateIncrementRequest = require('../lib/Models/CreateIncrementRequest');
 const UpdateInvoiceStatusRequest = require('../lib/Models/UpdateInvoiceStatusRequest');
-const GetAnticipationLimitResponse = require('../lib/Models/GetAnticipationLimitResponse');
 const GetUsageResponse = require('../lib/Models/GetUsageResponse');
 const CreateSubscriptionRequest = require('../lib/Models/CreateSubscriptionRequest');
 const CreateApplePayRequest = require('../lib/Models/CreateApplePayRequest');
+const GetAnticipationLimitResponse = require('../lib/Models/GetAnticipationLimitResponse');
 const UpdateCustomerRequest = require('../lib/Models/UpdateCustomerRequest');
 const GetSubscriptionResponse = require('../lib/Models/GetSubscriptionResponse');
 const GetPeriodResponse = require('../lib/Models/GetPeriodResponse');
 const CreateDebitCardPaymentRequest = require('../lib/Models/CreateDebitCardPaymentRequest');
 const CreateApplePayHeaderRequest = require('../lib/Models/CreateApplePayHeaderRequest');
-const CreateSellerRequest = require('../lib/Models/CreateSellerRequest');
-const GetTransferResponse = require('../lib/Models/GetTransferResponse');
 const CreateLocationRequest = require('../lib/Models/CreateLocationRequest');
 const UpdateOrderStatusRequest = require('../lib/Models/UpdateOrderStatusRequest');
 const CreateCreditCardPaymentRequest = require('../lib/Models/CreateCreditCardPaymentRequest');
 const ListDiscountsResponse = require('../lib/Models/ListDiscountsResponse');
 const CreateRecipientRequest = require('../lib/Models/CreateRecipientRequest');
+const GetTransferResponse = require('../lib/Models/GetTransferResponse');
 const ListRecipientResponse = require('../lib/Models/ListRecipientResponse');
 const GetDeviceResponse = require('../lib/Models/GetDeviceResponse');
 const CreatePaymentRequest = require('../lib/Models/CreatePaymentRequest');
 const GetTransactionResponse = require('../lib/Models/GetTransactionResponse');
 const UpdateRecipientBankAccountRequest =
   require('../lib/Models/UpdateRecipientBankAccountRequest');
-const UpdateSellerRequest = require('../lib/Models/UpdateSellerRequest');
 const UpdateTransferSettingsRequest = require('../lib/Models/UpdateTransferSettingsRequest');
-const CreateCancelChargeRequest = require('../lib/Models/CreateCancelChargeRequest');
-const UpdateSubscriptionStartAtRequest = require('../lib/Models/UpdateSubscriptionStartAtRequest');
-const CreateTransactionReportFileRequest =
-  require('../lib/Models/CreateTransactionReportFileRequest');
-const CreateCardRequest = require('../lib/Models/CreateCardRequest');
-const CreateEmvDataDukptDecryptRequest = require('../lib/Models/CreateEmvDataDukptDecryptRequest');
-const GetWithdrawTargetResponse = require('../lib/Models/GetWithdrawTargetResponse');
-const GetChargesSummaryResponse = require('../lib/Models/GetChargesSummaryResponse');
-const CreatePrivateLabelPaymentRequest = require('../lib/Models/CreatePrivateLabelPaymentRequest');
-const UpdateAutomaticAnticipationSettingsRequest =
-  require('../lib/Models/UpdateAutomaticAnticipationSettingsRequest');
+const GetBillingAddressResponse = require('../lib/Models/GetBillingAddressResponse');
+const CreateIncrementRequest = require('../lib/Models/CreateIncrementRequest');
 const CreateCashPaymentRequest = require('../lib/Models/CreateCashPaymentRequest');
-const CreateConfirmPaymentRequest = require('../lib/Models/CreateConfirmPaymentRequest');
+const CreateCancelChargeRequest = require('../lib/Models/CreateCancelChargeRequest');
 const CreateShippingRequest = require('../lib/Models/CreateShippingRequest');
 const GetCheckoutCreditCardPaymentResponse =
   require('../lib/Models/GetCheckoutCreditCardPaymentResponse');
 const CreateChargeRequest = require('../lib/Models/CreateChargeRequest');
 const CreateTransfer = require('../lib/Models/CreateTransfer');
+const CreateTransactionReportFileRequest =
+  require('../lib/Models/CreateTransactionReportFileRequest');
+const CreateCardRequest = require('../lib/Models/CreateCardRequest');
+const CreateEmvDataDukptDecryptRequest = require('../lib/Models/CreateEmvDataDukptDecryptRequest');
+const GetWithdrawTargetResponse = require('../lib/Models/GetWithdrawTargetResponse');
+const CreateCancelChargeSplitRulesRequest =
+  require('../lib/Models/CreateCancelChargeSplitRulesRequest');
+const UpdateSubscriptionStartAtRequest = require('../lib/Models/UpdateSubscriptionStartAtRequest');
+const CreatePixPaymentRequest = require('../lib/Models/CreatePixPaymentRequest');
+const GetChargesSummaryResponse = require('../lib/Models/GetChargesSummaryResponse');
+const CreatePrivateLabelPaymentRequest = require('../lib/Models/CreatePrivateLabelPaymentRequest');
+const UpdateAutomaticAnticipationSettingsRequest =
+  require('../lib/Models/UpdateAutomaticAnticipationSettingsRequest');
+const GetSplitResponse = require('../lib/Models/GetSplitResponse');
+const ListTransactionsFilesResponse = require('../lib/Models/ListTransactionsFilesResponse');
+const CreateEmvDataTlvDecryptRequest = require('../lib/Models/CreateEmvDataTlvDecryptRequest');
+const CreateEmvDecryptRequest = require('../lib/Models/CreateEmvDecryptRequest');
+const GetWithdrawSourceResponse = require('../lib/Models/GetWithdrawSourceResponse');
+const CreateConfirmPaymentRequest = require('../lib/Models/CreateConfirmPaymentRequest');
 const GetCheckoutDebitCardPaymentResponse =
   require('../lib/Models/GetCheckoutDebitCardPaymentResponse');
 const GetAnticipationResponse = require('../lib/Models/GetAnticipationResponse');
@@ -166,15 +169,9 @@ const GetPrivateLabelTransactionResponse =
   require('../lib/Models/GetPrivateLabelTransactionResponse');
 const CreateAutomaticAnticipationSettingsRequest =
   require('../lib/Models/CreateAutomaticAnticipationSettingsRequest');
-const CreateCancelChargeSplitRulesRequest =
-  require('../lib/Models/CreateCancelChargeSplitRulesRequest');
-const GetSplitResponse = require('../lib/Models/GetSplitResponse');
-const CreatePixPaymentRequest = require('../lib/Models/CreatePixPaymentRequest');
-const ListTransactionsFilesResponse = require('../lib/Models/ListTransactionsFilesResponse');
-const CreateEmvDataTlvDecryptRequest = require('../lib/Models/CreateEmvDataTlvDecryptRequest');
-const CreateEmvDecryptRequest = require('../lib/Models/CreateEmvDecryptRequest');
-const GetWithdrawSourceResponse = require('../lib/Models/GetWithdrawSourceResponse');
 const GetCashTransactionResponse = require('../lib/Models/GetCashTransactionResponse');
+const UpdateSubscriptionMinimumPriceRequest =
+  require('../lib/Models/UpdateSubscriptionMinimumPriceRequest');
 const CreateGooglePayRequest = require('../lib/Models/CreateGooglePayRequest');
 const UpdateSubscriptionPaymentMethodRequest =
   require('../lib/Models/UpdateSubscriptionPaymentMethodRequest');
@@ -182,8 +179,6 @@ const CreateAntifraudRequest = require('../lib/Models/CreateAntifraudRequest');
 const GetCheckoutBankTransferPaymentResponse =
   require('../lib/Models/GetCheckoutBankTransferPaymentResponse');
 const GetBankAccountResponse = require('../lib/Models/GetBankAccountResponse');
-const UpdateSubscriptionMinimumPriceRequest =
-  require('../lib/Models/UpdateSubscriptionMinimumPriceRequest');
 const CreateOrderItemRequest = require('../lib/Models/CreateOrderItemRequest');
 const CreateSplitOptionsRequest = require('../lib/Models/CreateSplitOptionsRequest');
 const GetTransactionReportFileResponse = require('../lib/Models/GetTransactionReportFileResponse');
@@ -192,6 +187,7 @@ const GetUsageReportResponse = require('../lib/Models/GetUsageReportResponse');
 const ListTransfers = require('../lib/Models/ListTransfers');
 const PixAdditionalInformation = require('../lib/Models/PixAdditionalInformation');
 const GetShippingResponse = require('../lib/Models/GetShippingResponse');
+const UpdateCurrentCycleEndDateRequest = require('../lib/Models/UpdateCurrentCycleEndDateRequest');
 const CreateCheckoutBankTransferRequest =
   require('../lib/Models/CreateCheckoutBankTransferRequest');
 const CreateCardPaymentContactlessRequest =
@@ -199,20 +195,20 @@ const CreateCardPaymentContactlessRequest =
 const CreateCustomerRequest = require('../lib/Models/CreateCustomerRequest');
 const GetTransferTargetResponse = require('../lib/Models/GetTransferTargetResponse');
 const ListWithdrawals = require('../lib/Models/ListWithdrawals');
-const UpdateCurrentCycleEndDateRequest = require('../lib/Models/UpdateCurrentCycleEndDateRequest');
-const CreateCheckoutCreditCardPaymentRequest =
-  require('../lib/Models/CreateCheckoutCreditCardPaymentRequest');
 const GetCheckoutPaymentResponse = require('../lib/Models/GetCheckoutPaymentResponse');
 const CreateEmvDataDecryptRequest = require('../lib/Models/CreateEmvDataDecryptRequest');
 const GetWithdrawResponse = require('../lib/Models/GetWithdrawResponse');
 const GetAutomaticAnticipationResponse = require('../lib/Models/GetAutomaticAnticipationResponse');
+const CreateCheckoutPaymentRequest = require('../lib/Models/CreateCheckoutPaymentRequest');
+const CreateCheckoutCreditCardPaymentRequest =
+  require('../lib/Models/CreateCheckoutCreditCardPaymentRequest');
+const GetTransfer = require('../lib/Models/GetTransfer');
 const CreateSplitRequest = require('../lib/Models/CreateSplitRequest');
 const UpdateCurrentCycleStatusRequest = require('../lib/Models/UpdateCurrentCycleStatusRequest');
 const CreateInvoiceRequest = require('../lib/Models/CreateInvoiceRequest');
 const GetTransferSettingsResponse = require('../lib/Models/GetTransferSettingsResponse');
-const CreateCheckoutPaymentRequest = require('../lib/Models/CreateCheckoutPaymentRequest');
 const CreatePeriodRequest = require('../lib/Models/CreatePeriodRequest');
-const GetTransfer = require('../lib/Models/GetTransfer');
+const GetPaymentAuthenticationResponse = require('../lib/Models/GetPaymentAuthenticationResponse');
 const GetThreeDSecureResponse = require('../lib/Models/GetThreeDSecureResponse');
 const CreateGooglePayHeaderRequest = require('../lib/Models/CreateGooglePayHeaderRequest');
 const GetOrderItemResponse = require('../lib/Models/GetOrderItemResponse');
@@ -221,7 +217,6 @@ const CreateCardPaymentContactlessPOIRequest =
   require('../lib/Models/CreateCardPaymentContactlessPOIRequest');
 const CreateWithdrawRequest = require('../lib/Models/CreateWithdrawRequest');
 const GetSplitOptionsResponse = require('../lib/Models/GetSplitOptionsResponse');
-const GetPaymentAuthenticationResponse = require('../lib/Models/GetPaymentAuthenticationResponse');
 const GetCreditCardTransactionResponse = require('../lib/Models/GetCreditCardTransactionResponse');
 const ListChargeTransactionsResponse = require('../lib/Models/ListChargeTransactionsResponse');
 const ListCyclesResponse = require('../lib/Models/ListCyclesResponse');
@@ -239,16 +234,17 @@ const ErrorException = require('../lib/Exceptions/ErrorException');
 const classMap = {
     ListInvoicesResponse,
     GetCheckoutBoletoPaymentResponse,
-    CreateCardOptionsRequest,
+    UpdatePriceBracketRequest,
     UpdateSubscriptionBillingDateRequest,
     ListChargesResponse,
     ListSubscriptionsResponse,
     PagingResponse,
+    CreateCardOptionsRequest,
     ListTransactionsResponse,
     GetPlanItemResponse,
+    ListCardsResponse,
     GetPhonesResponse,
     CreateCardTokenRequest,
-    ListCardsResponse,
     GetPricingSchemeResponse,
     GetPriceBracketResponse,
     GetTokenResponse,
@@ -281,45 +277,41 @@ const classMap = {
     CreatePriceBracketRequest,
     GetCardTokenResponse,
     GetCheckoutCardInstallmentOptionsResponse,
-    CreatePricingSchemeRequest,
     CreateCancelSubscriptionRequest,
     UpdateCardRequest,
     CreatePlanRequest,
     CreateBankTransferPaymentRequest,
+    CreatePricingSchemeRequest,
     CreatePhonesRequest,
     CreateVoucherPaymentRequest,
     CreateCheckoutBoletoPaymentRequest,
     UpdateChargeDueDateRequest,
-    ListSubscriptionItemsResponse,
     CreateAccessTokenRequest,
     GetPhoneResponse,
     GetVoucherTransactionResponse,
+    ListSubscriptionItemsResponse,
     ListOrderResponse,
     ListAddressesResponse,
     GetDiscountResponse,
     GetCustomerResponse,
     CreateAddressRequest,
-    UpdatePriceBracketRequest,
-    GetSellerResponse,
     CreateSubscriptionItemRequest,
-    GetSellersRequest,
     CreateOrderRequest,
     GetGatewayResponseResponse,
     CreateDeviceRequest,
     UpdateSubscriptionAffiliationIdRequest,
-    ListSellerResponse,
     GetIncrementResponse,
     CreateThreeDSecureRequest,
     UpdateChargePaymentMethodRequest,
     GetRecipientResponse,
     UpdateRecipientRequest,
+    GetGatewayRecipientResponse,
+    ListIncrementsResponse,
     CreateAnticipationRequest,
     GetAnticipationLimitsResponse,
     GetInvoiceItemResponse,
     CreateDiscountRequest,
     GetCardResponse,
-    GetGatewayRecipientResponse,
-    ListIncrementsResponse,
     CreateBankAccountRequest,
     GetBalanceResponse,
     UpdateOrderItemRequest,
@@ -327,74 +319,72 @@ const classMap = {
     ListAnticipationResponse,
     UpdateAddressRequest,
     GetBoletoTransactionResponse,
+    GetLocationResponse,
     GetSubscriptionItemResponse,
     GetDebitCardTransactionResponse,
-    GetLocationResponse,
     CreateTransferSettingsRequest,
-    GetGatewayErrorResponse,
     CreateTransferRequest,
-    GetBillingAddressResponse,
+    GetGatewayErrorResponse,
     ListTransferResponse,
     CreateUsageRequest,
     CreatePaymentAuthenticationRequest,
-    CreateIncrementRequest,
     UpdateInvoiceStatusRequest,
-    GetAnticipationLimitResponse,
     GetUsageResponse,
     CreateSubscriptionRequest,
     CreateApplePayRequest,
+    GetAnticipationLimitResponse,
     UpdateCustomerRequest,
     GetSubscriptionResponse,
     GetPeriodResponse,
     CreateDebitCardPaymentRequest,
     CreateApplePayHeaderRequest,
-    CreateSellerRequest,
-    GetTransferResponse,
     CreateLocationRequest,
     UpdateOrderStatusRequest,
     CreateCreditCardPaymentRequest,
     ListDiscountsResponse,
     CreateRecipientRequest,
+    GetTransferResponse,
     ListRecipientResponse,
     GetDeviceResponse,
     CreatePaymentRequest,
     GetTransactionResponse,
     UpdateRecipientBankAccountRequest,
-    UpdateSellerRequest,
     UpdateTransferSettingsRequest,
-    CreateCancelChargeRequest,
-    UpdateSubscriptionStartAtRequest,
-    CreateTransactionReportFileRequest,
-    CreateCardRequest,
-    CreateEmvDataDukptDecryptRequest,
-    GetWithdrawTargetResponse,
-    GetChargesSummaryResponse,
-    CreatePrivateLabelPaymentRequest,
-    UpdateAutomaticAnticipationSettingsRequest,
+    GetBillingAddressResponse,
+    CreateIncrementRequest,
     CreateCashPaymentRequest,
-    CreateConfirmPaymentRequest,
+    CreateCancelChargeRequest,
     CreateShippingRequest,
     GetCheckoutCreditCardPaymentResponse,
     CreateChargeRequest,
     CreateTransfer,
-    GetCheckoutDebitCardPaymentResponse,
-    GetAnticipationResponse,
-    GetPrivateLabelTransactionResponse,
-    CreateAutomaticAnticipationSettingsRequest,
+    CreateTransactionReportFileRequest,
+    CreateCardRequest,
+    CreateEmvDataDukptDecryptRequest,
+    GetWithdrawTargetResponse,
     CreateCancelChargeSplitRulesRequest,
-    GetSplitResponse,
+    UpdateSubscriptionStartAtRequest,
     CreatePixPaymentRequest,
+    GetChargesSummaryResponse,
+    CreatePrivateLabelPaymentRequest,
+    UpdateAutomaticAnticipationSettingsRequest,
+    GetSplitResponse,
     ListTransactionsFilesResponse,
     CreateEmvDataTlvDecryptRequest,
     CreateEmvDecryptRequest,
     GetWithdrawSourceResponse,
+    CreateConfirmPaymentRequest,
+    GetCheckoutDebitCardPaymentResponse,
+    GetAnticipationResponse,
+    GetPrivateLabelTransactionResponse,
+    CreateAutomaticAnticipationSettingsRequest,
     GetCashTransactionResponse,
+    UpdateSubscriptionMinimumPriceRequest,
     CreateGooglePayRequest,
     UpdateSubscriptionPaymentMethodRequest,
     CreateAntifraudRequest,
     GetCheckoutBankTransferPaymentResponse,
     GetBankAccountResponse,
-    UpdateSubscriptionMinimumPriceRequest,
     CreateOrderItemRequest,
     CreateSplitOptionsRequest,
     GetTransactionReportFileResponse,
@@ -403,24 +393,25 @@ const classMap = {
     ListTransfers,
     PixAdditionalInformation,
     GetShippingResponse,
+    UpdateCurrentCycleEndDateRequest,
     CreateCheckoutBankTransferRequest,
     CreateCardPaymentContactlessRequest,
     CreateCustomerRequest,
     GetTransferTargetResponse,
     ListWithdrawals,
-    UpdateCurrentCycleEndDateRequest,
-    CreateCheckoutCreditCardPaymentRequest,
     GetCheckoutPaymentResponse,
     CreateEmvDataDecryptRequest,
     GetWithdrawResponse,
     GetAutomaticAnticipationResponse,
+    CreateCheckoutPaymentRequest,
+    CreateCheckoutCreditCardPaymentRequest,
+    GetTransfer,
     CreateSplitRequest,
     UpdateCurrentCycleStatusRequest,
     CreateInvoiceRequest,
     GetTransferSettingsResponse,
-    CreateCheckoutPaymentRequest,
     CreatePeriodRequest,
-    GetTransfer,
+    GetPaymentAuthenticationResponse,
     GetThreeDSecureResponse,
     CreateGooglePayHeaderRequest,
     GetOrderItemResponse,
@@ -428,7 +419,6 @@ const classMap = {
     CreateCardPaymentContactlessPOIRequest,
     CreateWithdrawRequest,
     GetSplitOptionsResponse,
-    GetPaymentAuthenticationResponse,
     GetCreditCardTransactionResponse,
     ListChargeTransactionsResponse,
     ListCyclesResponse,

--- a/lib/Models/CreateOrderItemRequest.js
+++ b/lib/Models/CreateOrderItemRequest.js
@@ -22,8 +22,6 @@ class CreateOrderItemRequest extends BaseModel {
         this.amount = this.constructor.getValue(obj.amount);
         this.description = this.constructor.getValue(obj.description);
         this.quantity = this.constructor.getValue(obj.quantity);
-        this.seller = this.constructor.getValue(obj.seller);
-        this.sellerId = this.constructor.getValue(obj.sellerId || obj.seller_id);
         this.category = this.constructor.getValue(obj.category);
         this.code = this.constructor.getValue(obj.code);
     }
@@ -37,8 +35,6 @@ class CreateOrderItemRequest extends BaseModel {
             { name: 'amount', realName: 'amount' },
             { name: 'description', realName: 'description' },
             { name: 'quantity', realName: 'quantity' },
-            { name: 'seller', realName: 'seller', type: 'CreateSellerRequest' },
-            { name: 'sellerId', realName: 'seller_id' },
             { name: 'category', realName: 'category' },
             { name: 'code', realName: 'code' },
         ]);

--- a/lib/Models/GetOrderItemResponse.js
+++ b/lib/Models/GetOrderItemResponse.js
@@ -23,9 +23,6 @@ class GetOrderItemResponse extends BaseModel {
         this.amount = this.constructor.getValue(obj.amount);
         this.description = this.constructor.getValue(obj.description);
         this.quantity = this.constructor.getValue(obj.quantity);
-        this.getSellerResponse =
-          this.constructor.getValue(obj.getSellerResponse
-     || obj.GetSellerResponse);
         this.category = this.constructor.getValue(obj.category);
         this.code = this.constructor.getValue(obj.code);
     }
@@ -40,7 +37,6 @@ class GetOrderItemResponse extends BaseModel {
             { name: 'amount', realName: 'amount' },
             { name: 'description', realName: 'description' },
             { name: 'quantity', realName: 'quantity' },
-            { name: 'getSellerResponse', realName: 'GetSellerResponse', type: 'GetSellerResponse' },
             { name: 'category', realName: 'category' },
             { name: 'code', realName: 'code' },
         ]);

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,28 +9,28 @@
 const Configuration = require('./configuration');
 const PlansController = require('./Controllers/PlansController');
 const SubscriptionsController = require('./Controllers/SubscriptionsController');
-const InvoicesController = require('./Controllers/InvoicesController');
 const OrdersController = require('./Controllers/OrdersController');
+const InvoicesController = require('./Controllers/InvoicesController');
 const CustomersController = require('./Controllers/CustomersController');
-const RecipientsController = require('./Controllers/RecipientsController');
 const ChargesController = require('./Controllers/ChargesController');
 const TransfersController = require('./Controllers/TransfersController');
+const RecipientsController = require('./Controllers/RecipientsController');
 const TokensController = require('./Controllers/TokensController');
-const SellersController = require('./Controllers/SellersController');
 const TransactionsController = require('./Controllers/TransactionsController');
 const ListInvoicesResponse = require('./Models/ListInvoicesResponse');
 const GetCheckoutBoletoPaymentResponse = require('./Models/GetCheckoutBoletoPaymentResponse');
-const CreateCardOptionsRequest = require('./Models/CreateCardOptionsRequest');
+const UpdatePriceBracketRequest = require('./Models/UpdatePriceBracketRequest');
 const UpdateSubscriptionBillingDateRequest =
   require('./Models/UpdateSubscriptionBillingDateRequest');
 const ListChargesResponse = require('./Models/ListChargesResponse');
 const ListSubscriptionsResponse = require('./Models/ListSubscriptionsResponse');
 const PagingResponse = require('./Models/PagingResponse');
+const CreateCardOptionsRequest = require('./Models/CreateCardOptionsRequest');
 const ListTransactionsResponse = require('./Models/ListTransactionsResponse');
 const GetPlanItemResponse = require('./Models/GetPlanItemResponse');
+const ListCardsResponse = require('./Models/ListCardsResponse');
 const GetPhonesResponse = require('./Models/GetPhonesResponse');
 const CreateCardTokenRequest = require('./Models/CreateCardTokenRequest');
-const ListCardsResponse = require('./Models/ListCardsResponse');
 const GetPricingSchemeResponse = require('./Models/GetPricingSchemeResponse');
 const GetPriceBracketResponse = require('./Models/GetPriceBracketResponse');
 const GetTokenResponse = require('./Models/GetTokenResponse');
@@ -66,46 +66,42 @@ const CreatePriceBracketRequest = require('./Models/CreatePriceBracketRequest');
 const GetCardTokenResponse = require('./Models/GetCardTokenResponse');
 const GetCheckoutCardInstallmentOptionsResponse =
   require('./Models/GetCheckoutCardInstallmentOptionsResponse');
-const CreatePricingSchemeRequest = require('./Models/CreatePricingSchemeRequest');
 const CreateCancelSubscriptionRequest = require('./Models/CreateCancelSubscriptionRequest');
 const UpdateCardRequest = require('./Models/UpdateCardRequest');
 const CreatePlanRequest = require('./Models/CreatePlanRequest');
 const CreateBankTransferPaymentRequest = require('./Models/CreateBankTransferPaymentRequest');
+const CreatePricingSchemeRequest = require('./Models/CreatePricingSchemeRequest');
 const CreatePhonesRequest = require('./Models/CreatePhonesRequest');
 const CreateVoucherPaymentRequest = require('./Models/CreateVoucherPaymentRequest');
 const CreateCheckoutBoletoPaymentRequest = require('./Models/CreateCheckoutBoletoPaymentRequest');
 const UpdateChargeDueDateRequest = require('./Models/UpdateChargeDueDateRequest');
-const ListSubscriptionItemsResponse = require('./Models/ListSubscriptionItemsResponse');
 const CreateAccessTokenRequest = require('./Models/CreateAccessTokenRequest');
 const GetPhoneResponse = require('./Models/GetPhoneResponse');
 const GetVoucherTransactionResponse = require('./Models/GetVoucherTransactionResponse');
+const ListSubscriptionItemsResponse = require('./Models/ListSubscriptionItemsResponse');
 const ListOrderResponse = require('./Models/ListOrderResponse');
 const ListAddressesResponse = require('./Models/ListAddressesResponse');
 const GetDiscountResponse = require('./Models/GetDiscountResponse');
 const GetCustomerResponse = require('./Models/GetCustomerResponse');
 const CreateAddressRequest = require('./Models/CreateAddressRequest');
-const UpdatePriceBracketRequest = require('./Models/UpdatePriceBracketRequest');
-const GetSellerResponse = require('./Models/GetSellerResponse');
 const CreateSubscriptionItemRequest = require('./Models/CreateSubscriptionItemRequest');
-const GetSellersRequest = require('./Models/GetSellersRequest');
 const CreateOrderRequest = require('./Models/CreateOrderRequest');
 const GetGatewayResponseResponse = require('./Models/GetGatewayResponseResponse');
 const CreateDeviceRequest = require('./Models/CreateDeviceRequest');
 const UpdateSubscriptionAffiliationIdRequest =
   require('./Models/UpdateSubscriptionAffiliationIdRequest');
-const ListSellerResponse = require('./Models/ListSellerResponse');
 const GetIncrementResponse = require('./Models/GetIncrementResponse');
 const CreateThreeDSecureRequest = require('./Models/CreateThreeDSecureRequest');
 const UpdateChargePaymentMethodRequest = require('./Models/UpdateChargePaymentMethodRequest');
 const GetRecipientResponse = require('./Models/GetRecipientResponse');
 const UpdateRecipientRequest = require('./Models/UpdateRecipientRequest');
+const GetGatewayRecipientResponse = require('./Models/GetGatewayRecipientResponse');
+const ListIncrementsResponse = require('./Models/ListIncrementsResponse');
 const CreateAnticipationRequest = require('./Models/CreateAnticipationRequest');
 const GetAnticipationLimitsResponse = require('./Models/GetAnticipationLimitsResponse');
 const GetInvoiceItemResponse = require('./Models/GetInvoiceItemResponse');
 const CreateDiscountRequest = require('./Models/CreateDiscountRequest');
 const GetCardResponse = require('./Models/GetCardResponse');
-const GetGatewayRecipientResponse = require('./Models/GetGatewayRecipientResponse');
-const ListIncrementsResponse = require('./Models/ListIncrementsResponse');
 const CreateBankAccountRequest = require('./Models/CreateBankAccountRequest');
 const GetBalanceResponse = require('./Models/GetBalanceResponse');
 const UpdateOrderItemRequest = require('./Models/UpdateOrderItemRequest');
@@ -113,71 +109,71 @@ const CreateBoletoPaymentRequest = require('./Models/CreateBoletoPaymentRequest'
 const ListAnticipationResponse = require('./Models/ListAnticipationResponse');
 const UpdateAddressRequest = require('./Models/UpdateAddressRequest');
 const GetBoletoTransactionResponse = require('./Models/GetBoletoTransactionResponse');
+const GetLocationResponse = require('./Models/GetLocationResponse');
 const GetSubscriptionItemResponse = require('./Models/GetSubscriptionItemResponse');
 const GetDebitCardTransactionResponse = require('./Models/GetDebitCardTransactionResponse');
-const GetLocationResponse = require('./Models/GetLocationResponse');
 const CreateTransferSettingsRequest = require('./Models/CreateTransferSettingsRequest');
-const GetGatewayErrorResponse = require('./Models/GetGatewayErrorResponse');
 const CreateTransferRequest = require('./Models/CreateTransferRequest');
-const GetBillingAddressResponse = require('./Models/GetBillingAddressResponse');
+const GetGatewayErrorResponse = require('./Models/GetGatewayErrorResponse');
 const ListTransferResponse = require('./Models/ListTransferResponse');
 const CreateUsageRequest = require('./Models/CreateUsageRequest');
 const CreatePaymentAuthenticationRequest = require('./Models/CreatePaymentAuthenticationRequest');
-const CreateIncrementRequest = require('./Models/CreateIncrementRequest');
 const UpdateInvoiceStatusRequest = require('./Models/UpdateInvoiceStatusRequest');
-const GetAnticipationLimitResponse = require('./Models/GetAnticipationLimitResponse');
 const GetUsageResponse = require('./Models/GetUsageResponse');
 const CreateSubscriptionRequest = require('./Models/CreateSubscriptionRequest');
 const CreateApplePayRequest = require('./Models/CreateApplePayRequest');
+const GetAnticipationLimitResponse = require('./Models/GetAnticipationLimitResponse');
 const UpdateCustomerRequest = require('./Models/UpdateCustomerRequest');
 const GetSubscriptionResponse = require('./Models/GetSubscriptionResponse');
 const GetPeriodResponse = require('./Models/GetPeriodResponse');
 const CreateDebitCardPaymentRequest = require('./Models/CreateDebitCardPaymentRequest');
 const CreateApplePayHeaderRequest = require('./Models/CreateApplePayHeaderRequest');
-const CreateSellerRequest = require('./Models/CreateSellerRequest');
-const GetTransferResponse = require('./Models/GetTransferResponse');
 const CreateLocationRequest = require('./Models/CreateLocationRequest');
 const UpdateOrderStatusRequest = require('./Models/UpdateOrderStatusRequest');
 const CreateCreditCardPaymentRequest = require('./Models/CreateCreditCardPaymentRequest');
 const ListDiscountsResponse = require('./Models/ListDiscountsResponse');
 const CreateRecipientRequest = require('./Models/CreateRecipientRequest');
+const GetTransferResponse = require('./Models/GetTransferResponse');
 const ListRecipientResponse = require('./Models/ListRecipientResponse');
 const GetDeviceResponse = require('./Models/GetDeviceResponse');
 const CreatePaymentRequest = require('./Models/CreatePaymentRequest');
 const GetTransactionResponse = require('./Models/GetTransactionResponse');
 const UpdateRecipientBankAccountRequest = require('./Models/UpdateRecipientBankAccountRequest');
-const UpdateSellerRequest = require('./Models/UpdateSellerRequest');
 const UpdateTransferSettingsRequest = require('./Models/UpdateTransferSettingsRequest');
-const CreateCancelChargeRequest = require('./Models/CreateCancelChargeRequest');
-const UpdateSubscriptionStartAtRequest = require('./Models/UpdateSubscriptionStartAtRequest');
-const CreateTransactionReportFileRequest = require('./Models/CreateTransactionReportFileRequest');
-const CreateCardRequest = require('./Models/CreateCardRequest');
-const CreateEmvDataDukptDecryptRequest = require('./Models/CreateEmvDataDukptDecryptRequest');
-const GetWithdrawTargetResponse = require('./Models/GetWithdrawTargetResponse');
-const GetChargesSummaryResponse = require('./Models/GetChargesSummaryResponse');
-const CreatePrivateLabelPaymentRequest = require('./Models/CreatePrivateLabelPaymentRequest');
-const UpdateAutomaticAnticipationSettingsRequest =
-  require('./Models/UpdateAutomaticAnticipationSettingsRequest');
+const GetBillingAddressResponse = require('./Models/GetBillingAddressResponse');
+const CreateIncrementRequest = require('./Models/CreateIncrementRequest');
 const CreateCashPaymentRequest = require('./Models/CreateCashPaymentRequest');
-const CreateConfirmPaymentRequest = require('./Models/CreateConfirmPaymentRequest');
+const CreateCancelChargeRequest = require('./Models/CreateCancelChargeRequest');
 const CreateShippingRequest = require('./Models/CreateShippingRequest');
 const GetCheckoutCreditCardPaymentResponse =
   require('./Models/GetCheckoutCreditCardPaymentResponse');
 const CreateChargeRequest = require('./Models/CreateChargeRequest');
 const CreateTransfer = require('./Models/CreateTransfer');
+const CreateTransactionReportFileRequest = require('./Models/CreateTransactionReportFileRequest');
+const CreateCardRequest = require('./Models/CreateCardRequest');
+const CreateEmvDataDukptDecryptRequest = require('./Models/CreateEmvDataDukptDecryptRequest');
+const GetWithdrawTargetResponse = require('./Models/GetWithdrawTargetResponse');
+const CreateCancelChargeSplitRulesRequest = require('./Models/CreateCancelChargeSplitRulesRequest');
+const UpdateSubscriptionStartAtRequest = require('./Models/UpdateSubscriptionStartAtRequest');
+const CreatePixPaymentRequest = require('./Models/CreatePixPaymentRequest');
+const GetChargesSummaryResponse = require('./Models/GetChargesSummaryResponse');
+const CreatePrivateLabelPaymentRequest = require('./Models/CreatePrivateLabelPaymentRequest');
+const UpdateAutomaticAnticipationSettingsRequest =
+  require('./Models/UpdateAutomaticAnticipationSettingsRequest');
+const GetSplitResponse = require('./Models/GetSplitResponse');
+const ListTransactionsFilesResponse = require('./Models/ListTransactionsFilesResponse');
+const CreateEmvDataTlvDecryptRequest = require('./Models/CreateEmvDataTlvDecryptRequest');
+const CreateEmvDecryptRequest = require('./Models/CreateEmvDecryptRequest');
+const GetWithdrawSourceResponse = require('./Models/GetWithdrawSourceResponse');
+const CreateConfirmPaymentRequest = require('./Models/CreateConfirmPaymentRequest');
 const GetCheckoutDebitCardPaymentResponse = require('./Models/GetCheckoutDebitCardPaymentResponse');
 const GetAnticipationResponse = require('./Models/GetAnticipationResponse');
 const GetPrivateLabelTransactionResponse = require('./Models/GetPrivateLabelTransactionResponse');
 const CreateAutomaticAnticipationSettingsRequest =
   require('./Models/CreateAutomaticAnticipationSettingsRequest');
-const CreateCancelChargeSplitRulesRequest = require('./Models/CreateCancelChargeSplitRulesRequest');
-const GetSplitResponse = require('./Models/GetSplitResponse');
-const CreatePixPaymentRequest = require('./Models/CreatePixPaymentRequest');
-const ListTransactionsFilesResponse = require('./Models/ListTransactionsFilesResponse');
-const CreateEmvDataTlvDecryptRequest = require('./Models/CreateEmvDataTlvDecryptRequest');
-const CreateEmvDecryptRequest = require('./Models/CreateEmvDecryptRequest');
-const GetWithdrawSourceResponse = require('./Models/GetWithdrawSourceResponse');
 const GetCashTransactionResponse = require('./Models/GetCashTransactionResponse');
+const UpdateSubscriptionMinimumPriceRequest =
+  require('./Models/UpdateSubscriptionMinimumPriceRequest');
 const CreateGooglePayRequest = require('./Models/CreateGooglePayRequest');
 const UpdateSubscriptionPaymentMethodRequest =
   require('./Models/UpdateSubscriptionPaymentMethodRequest');
@@ -185,8 +181,6 @@ const CreateAntifraudRequest = require('./Models/CreateAntifraudRequest');
 const GetCheckoutBankTransferPaymentResponse =
   require('./Models/GetCheckoutBankTransferPaymentResponse');
 const GetBankAccountResponse = require('./Models/GetBankAccountResponse');
-const UpdateSubscriptionMinimumPriceRequest =
-  require('./Models/UpdateSubscriptionMinimumPriceRequest');
 const CreateOrderItemRequest = require('./Models/CreateOrderItemRequest');
 const CreateSplitOptionsRequest = require('./Models/CreateSplitOptionsRequest');
 const GetTransactionReportFileResponse = require('./Models/GetTransactionReportFileResponse');
@@ -195,25 +189,26 @@ const GetUsageReportResponse = require('./Models/GetUsageReportResponse');
 const ListTransfers = require('./Models/ListTransfers');
 const PixAdditionalInformation = require('./Models/PixAdditionalInformation');
 const GetShippingResponse = require('./Models/GetShippingResponse');
+const UpdateCurrentCycleEndDateRequest = require('./Models/UpdateCurrentCycleEndDateRequest');
 const CreateCheckoutBankTransferRequest = require('./Models/CreateCheckoutBankTransferRequest');
 const CreateCardPaymentContactlessRequest = require('./Models/CreateCardPaymentContactlessRequest');
 const CreateCustomerRequest = require('./Models/CreateCustomerRequest');
 const GetTransferTargetResponse = require('./Models/GetTransferTargetResponse');
 const ListWithdrawals = require('./Models/ListWithdrawals');
-const UpdateCurrentCycleEndDateRequest = require('./Models/UpdateCurrentCycleEndDateRequest');
-const CreateCheckoutCreditCardPaymentRequest =
-  require('./Models/CreateCheckoutCreditCardPaymentRequest');
 const GetCheckoutPaymentResponse = require('./Models/GetCheckoutPaymentResponse');
 const CreateEmvDataDecryptRequest = require('./Models/CreateEmvDataDecryptRequest');
 const GetWithdrawResponse = require('./Models/GetWithdrawResponse');
 const GetAutomaticAnticipationResponse = require('./Models/GetAutomaticAnticipationResponse');
+const CreateCheckoutPaymentRequest = require('./Models/CreateCheckoutPaymentRequest');
+const CreateCheckoutCreditCardPaymentRequest =
+  require('./Models/CreateCheckoutCreditCardPaymentRequest');
+const GetTransfer = require('./Models/GetTransfer');
 const CreateSplitRequest = require('./Models/CreateSplitRequest');
 const UpdateCurrentCycleStatusRequest = require('./Models/UpdateCurrentCycleStatusRequest');
 const CreateInvoiceRequest = require('./Models/CreateInvoiceRequest');
 const GetTransferSettingsResponse = require('./Models/GetTransferSettingsResponse');
-const CreateCheckoutPaymentRequest = require('./Models/CreateCheckoutPaymentRequest');
 const CreatePeriodRequest = require('./Models/CreatePeriodRequest');
-const GetTransfer = require('./Models/GetTransfer');
+const GetPaymentAuthenticationResponse = require('./Models/GetPaymentAuthenticationResponse');
 const GetThreeDSecureResponse = require('./Models/GetThreeDSecureResponse');
 const CreateGooglePayHeaderRequest = require('./Models/CreateGooglePayHeaderRequest');
 const GetOrderItemResponse = require('./Models/GetOrderItemResponse');
@@ -222,7 +217,6 @@ const CreateCardPaymentContactlessPOIRequest =
   require('./Models/CreateCardPaymentContactlessPOIRequest');
 const CreateWithdrawRequest = require('./Models/CreateWithdrawRequest');
 const GetSplitOptionsResponse = require('./Models/GetSplitOptionsResponse');
-const GetPaymentAuthenticationResponse = require('./Models/GetPaymentAuthenticationResponse');
 const GetCreditCardTransactionResponse = require('./Models/GetCreditCardTransactionResponse');
 const ListChargeTransactionsResponse = require('./Models/ListChargeTransactionsResponse');
 const ListCyclesResponse = require('./Models/ListCyclesResponse');
@@ -245,28 +239,28 @@ const initializer = {
     // controllers of PagarmeCoreApiLib
     PlansController,
     SubscriptionsController,
-    InvoicesController,
     OrdersController,
+    InvoicesController,
     CustomersController,
-    RecipientsController,
     ChargesController,
     TransfersController,
+    RecipientsController,
     TokensController,
-    SellersController,
     TransactionsController,
     // models of PagarmeCoreApiLib
     ListInvoicesResponse,
     GetCheckoutBoletoPaymentResponse,
-    CreateCardOptionsRequest,
+    UpdatePriceBracketRequest,
     UpdateSubscriptionBillingDateRequest,
     ListChargesResponse,
     ListSubscriptionsResponse,
     PagingResponse,
+    CreateCardOptionsRequest,
     ListTransactionsResponse,
     GetPlanItemResponse,
+    ListCardsResponse,
     GetPhonesResponse,
     CreateCardTokenRequest,
-    ListCardsResponse,
     GetPricingSchemeResponse,
     GetPriceBracketResponse,
     GetTokenResponse,
@@ -299,45 +293,41 @@ const initializer = {
     CreatePriceBracketRequest,
     GetCardTokenResponse,
     GetCheckoutCardInstallmentOptionsResponse,
-    CreatePricingSchemeRequest,
     CreateCancelSubscriptionRequest,
     UpdateCardRequest,
     CreatePlanRequest,
     CreateBankTransferPaymentRequest,
+    CreatePricingSchemeRequest,
     CreatePhonesRequest,
     CreateVoucherPaymentRequest,
     CreateCheckoutBoletoPaymentRequest,
     UpdateChargeDueDateRequest,
-    ListSubscriptionItemsResponse,
     CreateAccessTokenRequest,
     GetPhoneResponse,
     GetVoucherTransactionResponse,
+    ListSubscriptionItemsResponse,
     ListOrderResponse,
     ListAddressesResponse,
     GetDiscountResponse,
     GetCustomerResponse,
     CreateAddressRequest,
-    UpdatePriceBracketRequest,
-    GetSellerResponse,
     CreateSubscriptionItemRequest,
-    GetSellersRequest,
     CreateOrderRequest,
     GetGatewayResponseResponse,
     CreateDeviceRequest,
     UpdateSubscriptionAffiliationIdRequest,
-    ListSellerResponse,
     GetIncrementResponse,
     CreateThreeDSecureRequest,
     UpdateChargePaymentMethodRequest,
     GetRecipientResponse,
     UpdateRecipientRequest,
+    GetGatewayRecipientResponse,
+    ListIncrementsResponse,
     CreateAnticipationRequest,
     GetAnticipationLimitsResponse,
     GetInvoiceItemResponse,
     CreateDiscountRequest,
     GetCardResponse,
-    GetGatewayRecipientResponse,
-    ListIncrementsResponse,
     CreateBankAccountRequest,
     GetBalanceResponse,
     UpdateOrderItemRequest,
@@ -345,74 +335,72 @@ const initializer = {
     ListAnticipationResponse,
     UpdateAddressRequest,
     GetBoletoTransactionResponse,
+    GetLocationResponse,
     GetSubscriptionItemResponse,
     GetDebitCardTransactionResponse,
-    GetLocationResponse,
     CreateTransferSettingsRequest,
-    GetGatewayErrorResponse,
     CreateTransferRequest,
-    GetBillingAddressResponse,
+    GetGatewayErrorResponse,
     ListTransferResponse,
     CreateUsageRequest,
     CreatePaymentAuthenticationRequest,
-    CreateIncrementRequest,
     UpdateInvoiceStatusRequest,
-    GetAnticipationLimitResponse,
     GetUsageResponse,
     CreateSubscriptionRequest,
     CreateApplePayRequest,
+    GetAnticipationLimitResponse,
     UpdateCustomerRequest,
     GetSubscriptionResponse,
     GetPeriodResponse,
     CreateDebitCardPaymentRequest,
     CreateApplePayHeaderRequest,
-    CreateSellerRequest,
-    GetTransferResponse,
     CreateLocationRequest,
     UpdateOrderStatusRequest,
     CreateCreditCardPaymentRequest,
     ListDiscountsResponse,
     CreateRecipientRequest,
+    GetTransferResponse,
     ListRecipientResponse,
     GetDeviceResponse,
     CreatePaymentRequest,
     GetTransactionResponse,
     UpdateRecipientBankAccountRequest,
-    UpdateSellerRequest,
     UpdateTransferSettingsRequest,
-    CreateCancelChargeRequest,
-    UpdateSubscriptionStartAtRequest,
-    CreateTransactionReportFileRequest,
-    CreateCardRequest,
-    CreateEmvDataDukptDecryptRequest,
-    GetWithdrawTargetResponse,
-    GetChargesSummaryResponse,
-    CreatePrivateLabelPaymentRequest,
-    UpdateAutomaticAnticipationSettingsRequest,
+    GetBillingAddressResponse,
+    CreateIncrementRequest,
     CreateCashPaymentRequest,
-    CreateConfirmPaymentRequest,
+    CreateCancelChargeRequest,
     CreateShippingRequest,
     GetCheckoutCreditCardPaymentResponse,
     CreateChargeRequest,
     CreateTransfer,
-    GetCheckoutDebitCardPaymentResponse,
-    GetAnticipationResponse,
-    GetPrivateLabelTransactionResponse,
-    CreateAutomaticAnticipationSettingsRequest,
+    CreateTransactionReportFileRequest,
+    CreateCardRequest,
+    CreateEmvDataDukptDecryptRequest,
+    GetWithdrawTargetResponse,
     CreateCancelChargeSplitRulesRequest,
-    GetSplitResponse,
+    UpdateSubscriptionStartAtRequest,
     CreatePixPaymentRequest,
+    GetChargesSummaryResponse,
+    CreatePrivateLabelPaymentRequest,
+    UpdateAutomaticAnticipationSettingsRequest,
+    GetSplitResponse,
     ListTransactionsFilesResponse,
     CreateEmvDataTlvDecryptRequest,
     CreateEmvDecryptRequest,
     GetWithdrawSourceResponse,
+    CreateConfirmPaymentRequest,
+    GetCheckoutDebitCardPaymentResponse,
+    GetAnticipationResponse,
+    GetPrivateLabelTransactionResponse,
+    CreateAutomaticAnticipationSettingsRequest,
     GetCashTransactionResponse,
+    UpdateSubscriptionMinimumPriceRequest,
     CreateGooglePayRequest,
     UpdateSubscriptionPaymentMethodRequest,
     CreateAntifraudRequest,
     GetCheckoutBankTransferPaymentResponse,
     GetBankAccountResponse,
-    UpdateSubscriptionMinimumPriceRequest,
     CreateOrderItemRequest,
     CreateSplitOptionsRequest,
     GetTransactionReportFileResponse,
@@ -421,24 +409,25 @@ const initializer = {
     ListTransfers,
     PixAdditionalInformation,
     GetShippingResponse,
+    UpdateCurrentCycleEndDateRequest,
     CreateCheckoutBankTransferRequest,
     CreateCardPaymentContactlessRequest,
     CreateCustomerRequest,
     GetTransferTargetResponse,
     ListWithdrawals,
-    UpdateCurrentCycleEndDateRequest,
-    CreateCheckoutCreditCardPaymentRequest,
     GetCheckoutPaymentResponse,
     CreateEmvDataDecryptRequest,
     GetWithdrawResponse,
     GetAutomaticAnticipationResponse,
+    CreateCheckoutPaymentRequest,
+    CreateCheckoutCreditCardPaymentRequest,
+    GetTransfer,
     CreateSplitRequest,
     UpdateCurrentCycleStatusRequest,
     CreateInvoiceRequest,
     GetTransferSettingsResponse,
-    CreateCheckoutPaymentRequest,
     CreatePeriodRequest,
-    GetTransfer,
+    GetPaymentAuthenticationResponse,
     GetThreeDSecureResponse,
     CreateGooglePayHeaderRequest,
     GetOrderItemResponse,
@@ -446,7 +435,6 @@ const initializer = {
     CreateCardPaymentContactlessPOIRequest,
     CreateWithdrawRequest,
     GetSplitOptionsResponse,
-    GetPaymentAuthenticationResponse,
     GetCreditCardTransactionResponse,
     ListChargeTransactionsResponse,
     ListCyclesResponse,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pagarmecoreapilib",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "description": "Pagarme API",
   "main": "./lib/index.js",
   "repository": {


### PR DESCRIPTION
The customer should no longer use the Mark1 Sellers endpoint as it is outdated. We need to remove it from the SDK so it no longer has access.